### PR TITLE
feat: GitHubEvent を AI で要約し SnsPost を生成するエンドポイントを追加 #3

### DIFF
--- a/src/app/api/ai/summarize/route.ts
+++ b/src/app/api/ai/summarize/route.ts
@@ -1,0 +1,90 @@
+// src/app/api/ai/summarize/route.ts
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/server/db/client"
+import { generateSummaryFromGithubEvent } from "@/server/ai/generateSummaryFromGithubEvent"
+
+const bodySchema = z.object({
+  githubEventId: z.string().min(1),
+})
+
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === "string") return err
+  try {
+    return JSON.stringify(err)
+  } catch {
+    return "unknown error"
+  }
+}
+
+export async function POST(req: NextRequest) {
+  let body: z.infer<typeof bodySchema>
+
+  // 1. リクエストボディのバリデーション
+  try {
+    const json = await req.json()
+    body = bodySchema.parse(json)
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+  }
+
+  const { githubEventId } = body
+
+  // 2. 対象の GithubEvent を取得
+  const githubEvent = await prisma.githubEvent.findUnique({
+    where: { id: githubEventId },
+  })
+
+  if (!githubEvent) {
+    return NextResponse.json(
+      { error: "GithubEvent not found" },
+      { status: 404 },
+    )
+  }
+
+  // 3. AI 要約（フェーズ1は擬似要約）
+  try {
+    const summary = await generateSummaryFromGithubEvent(githubEvent)
+
+    const snsPost = await prisma.snsPost.create({
+      data: {
+        eventId: githubEvent.id,
+        platform: "ai-preview",
+        content: summary,
+        status: "SUCCESS",
+        // externalId, errorMessage は不要なので未設定
+      },
+    })
+
+    return NextResponse.json({
+      ok: true,
+      snsPostId: snsPost.id,
+      content: snsPost.content,
+    })
+  } catch (err) {
+    // 4. 失敗時も FAILED ログとして残す
+    const errorMessage = getErrorMessage(err)
+
+    const failedPost = await prisma.snsPost.create({
+      data: {
+        eventId: githubEvent.id,
+        platform: "ai-preview",
+        content: "",
+        status: "FAILED",
+        errorMessage,
+      },
+    })
+
+    console.error("[api/ai/summarize] failed to generate summary", err)
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Failed to generate summary",
+        snsPostId: failedPost.id,
+      },
+      { status: 500 },
+    )
+  }
+}

--- a/src/server/ai/generateSummaryFromGithubEvent.ts
+++ b/src/server/ai/generateSummaryFromGithubEvent.ts
@@ -1,0 +1,39 @@
+// src/server/ai/generateSummaryFromGithubEvent.ts
+import type { GithubEvent } from "@prisma/client"
+
+/**
+ * 将来的に AI 用のプロンプトを組み立てる関数。
+ * まずはテンプレートでの「なんちゃって要約」を返す。
+ */
+export function buildPromptFromGithubEvent(event: GithubEvent): string {
+  return [
+    `リポジトリ: ${event.repoName}`,
+    `PR #${event.prNumber}: ${event.prTitle}`,
+    event.prUrl ? `URL: ${event.prUrl}` : "",
+    event.mergedBy ? `マージした人: ${event.mergedBy}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+}
+
+/**
+ * フェーズ1: 擬似 AI 要約。
+ * - 後からここを OpenAI / Claude などの呼び出しに差し替える想定。
+ */
+export async function generateSummaryFromGithubEvent(
+  event: GithubEvent,
+): Promise<string> {
+  const baseInfo = buildPromptFromGithubEvent(event)
+
+  // TODO: ここを本物の AI 呼び出しに差し替える
+  // 例: OpenAI に baseInfo を投げて、SNS 向けの 200 文字要約を生成する…など
+  const summaryLines = [
+    "GitHub の PR マージ内容を要約しました。",
+    "",
+    baseInfo,
+    "",
+    "この PR では、リポジトリの改善・機能追加・バグ修正などが行われています。",
+  ]
+
+  return summaryLines.join("\n")
+}


### PR DESCRIPTION
## 概要

GitHub の PR マージイベント（`GithubEvent`）をもとに、  
AI（フェーズ1では擬似要約）で内容を要約し、`SnsPost` として保存する API エンドポイントを実装しました。

本 PR では「要約生成 + DB 保存」までを責務とし、  
実際の SNS 投稿処理や /dashboard 表示は別 Issue で対応します。

---

## この PR でやったこと

### 1. AI 要約ロジックの追加

- `src/server/ai/generateSummaryFromGithubEvent.ts`
  - `GithubEvent` を元に要約用テキストを生成するヘルパーを追加
  - フェーズ1ではテンプレートベースの擬似要約を返す実装
  - 後から OpenAI / Claude 等の AI API に差し替え可能な構造

### 2. AI 要約エンドポイントの実装

- `POST /api/ai/summarize`
- リクエスト例：

  ```json
  {
    "githubEventId": "clxxxxxxxxxxxxxxxxxxxx"
  }
```
- 処理内容：
1. リクエストボディをバリデーション
2. githubEventId から GithubEvent を取得
3. AI 要約を生成
4. SnsPost を作成
  - eventId: 対象 GithubEvent.id
  - platform: "ai-preview"
  - content: 生成された要約文
  - status: "SUCCESS"
5. 失敗時は status = "FAILED" の SnsPost を作成し、errorMessage に内容を保存

- 成功時レスポンス例：
```json
{
  "ok": true,
  "snsPostId": "cmiz5s7c40001qz8opmeixy4i",
  "content": "GitHub の PR マージ内容を要約しました..."
}
```
## 動作確認
以下の手順でローカル動作確認を行いました。

1. Prisma Studio で GithubEvent.id を確認
```bash
npx prisma studio
```
2. AI 要約エンドポイント呼び出し
```bash
EVENT_ID="(GithubEvent の id)"

curl -X POST http://localhost:3000/api/ai/summarize \
  -H "Content-Type: application/json" \
  -d "{\"githubEventId\":\"$EVENT_ID\"}"
```
3. `SnsPost` テーブルに以下が作成されていることを確認
- eventId が対象 GithubEvent.id
- platform = "ai-preview"
- status = "SUCCESS"
- content に要約文が保存されている

---
## この PR でやらないこと
- 実際の AI API（OpenAI / Claude など）との連携
- SNS / Webhook への投稿処理
- /dashboard でのイベント・投稿ログ表示
これらは別 Issue で対応予定です。

## 関連 Issue
#3 feat: GitHubEvent を AI で要約し SnsPost を生成するエンドポイントの実装

