### PR TITLE
feat: /dashboard から AI 要約を再生成できるようにする (#7)

### DIFF
--- a/src/app/components/github-event-card.tsx
+++ b/src/app/components/github-event-card.tsx
@@ -1,75 +1,77 @@
-"use client";
+"use client"
 
-import { useState } from "react";
-import { Button } from "@/app/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/app/components/ui/card";
-import { StatusBadge } from "@/app/components/status-badge";
-import { ExternalLink, Copy, RefreshCw } from "lucide-react";
-import { useToast } from "@/app/hooks/use-toast";
+import { useState } from "react"
+import { Button } from "@/app/components/ui/button"
+import { Card, CardContent, CardHeader } from "@/app/components/ui/card"
+import { StatusBadge } from "@/app/components/status-badge"
+import { ExternalLink, Copy, RefreshCw } from "lucide-react"
+import { useToast } from "@/app/hooks/use-toast"
+import { useSummarize } from "@/app/hooks/use-summarize"
 
 interface GithubEvent {
-  id: string;
-  repository: string;
-  prTitle: string;
-  prNumber: number;
-  githubUrl: string;
-  mergedBy: string;
-  mergedAt: string;
-  status: "SUCCESS" | "FAILED" | "NONE";
-  aiSummary?: string;
-  snsDraft?: string;
+  id: string
+  repository: string
+  prTitle: string
+  prNumber: number
+  githubUrl: string
+  mergedBy: string
+  mergedAt: string
+  status: "SUCCESS" | "FAILED" | "NONE"
+  aiSummary?: string
+  snsDraft?: string
 }
 
 export function GithubEventCard({ event }: { event: GithubEvent }) {
-  const { toast } = useToast();
-  const [isRegenerating, setIsRegenerating] = useState(false);
+  const { toast } = useToast()
+  const [isCopying, setIsCopying] = useState(false)
+
+  // ここでフック呼び出し
+  const { summarize, isLoading: isRegenerating } = useSummarize({
+    githubEventId: event.id,
+  })
 
   const handleCopy = async (text: string) => {
-    await navigator.clipboard.writeText(text);
-    toast({
-      description: "テキストをコピーしました",
-    });
-  };
-
-  const handleRegenerate = () => {
-    setIsRegenerating(true);
-    setTimeout(() => {
-      setIsRegenerating(false);
+    try {
+      setIsCopying(true)
+      await navigator.clipboard.writeText(text)
       toast({
-        description: "再生成を開始しました",
-      });
-    }, 1000);
-  };
+        description: "テキストをコピーしました",
+      })
+    } catch {
+      toast({
+        variant: "destructive",
+        description: "コピーに失敗しました",
+      })
+    } finally {
+      setIsCopying(false)
+    }
+  }
 
   return (
-    <Card className="group overflow-hidden border-border/50 transition-all duration-300 hover:shadow-lg hover:-translate-y-1">
-      <CardHeader className="border-b border-border/50 bg-muted/20 p-5">
+    <Card className="group border-border/50 overflow-hidden transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
+      <CardHeader className="border-border/50 bg-muted/20 border-b p-5">
         <div className="flex items-start justify-between gap-4">
-          <div className="flex-1 space-y-2 min-w-0">
-            <div className="flex items-center gap-2 flex-wrap">
-              <h3 className="text-xs font-mono text-muted-foreground">
-                {event.repository}
-              </h3>
-              <span className="text-xs font-mono text-muted-foreground/70">
-                #{event.prNumber}
-              </span>
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-muted-foreground font-mono text-xs">{event.repository}</h3>
+              <span className="text-muted-foreground/70 font-mono text-xs">#{event.prNumber}</span>
             </div>
-            <h2 className="text-base font-semibold leading-snug text-balance text-foreground">
+            <h2 className="text-foreground text-base leading-snug font-semibold text-balance">
               {event.prTitle}
             </h2>
-            <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            <div className="text-muted-foreground flex items-center gap-3 text-xs">
               <span className="font-medium">{event.mergedBy}</span>
               <span className="opacity-50">•</span>
               <time>{event.mergedAt}</time>
             </div>
           </div>
-          <div className="flex flex-col items-end gap-2.5 flex-shrink-0">
+          <div className="flex flex-shrink-0 flex-col items-end gap-2.5">
             <StatusBadge status={event.status} />
             <Button
               variant="outline"
               size="sm"
               asChild
-              className="h-8 text-xs hover:bg-foreground hover:text-background transition-all bg-transparent"
+              className="hover:bg-foreground hover:text-background h-8 bg-transparent text-xs transition-all"
             >
               <a
                 href={event.githubUrl}
@@ -88,10 +90,10 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
       <CardContent className="space-y-6 p-5">
         {event.aiSummary && (
           <div className="space-y-2.5">
-            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <h4 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
               AI 要約
             </h4>
-            <div className="rounded-lg bg-muted/30 border border-border/50 p-4 text-sm leading-relaxed text-foreground/90">
+            <div className="bg-muted/30 border-border/50 text-foreground/90 rounded-lg border p-4 text-sm leading-relaxed">
               {event.aiSummary}
             </div>
           </div>
@@ -99,10 +101,10 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
 
         {event.snsDraft && (
           <div className="space-y-2.5">
-            <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <h4 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
               SNS 用ドラフト
             </h4>
-            <div className="rounded-lg border border-border/50 bg-card p-4 text-sm leading-relaxed font-mono text-foreground/90 whitespace-pre-wrap">
+            <div className="border-border/50 bg-card text-foreground/90 rounded-lg border p-4 font-mono text-sm leading-relaxed whitespace-pre-wrap">
               {event.snsDraft}
             </div>
             <div className="flex gap-2">
@@ -110,27 +112,44 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
                 variant="outline"
                 size="sm"
                 onClick={() => handleCopy(event.snsDraft!)}
-                className="h-9 text-xs hover:bg-foreground hover:text-background transition-all"
+                disabled={isCopying}
+                className="hover:bg-foreground hover:text-background h-9 text-xs transition-all"
               >
                 <Copy className="mr-1.5 h-3.5 w-3.5" />
-                コピー
+                {isCopying ? "コピー中..." : "コピー"}
               </Button>
               <Button
                 variant="outline"
                 size="sm"
-                onClick={handleRegenerate}
+                onClick={summarize}
                 disabled={isRegenerating}
-                className="h-9 text-xs hover:bg-foreground hover:text-background transition-all bg-transparent"
+                className="hover:bg-foreground hover:text-background h-9 bg-transparent text-xs transition-all"
               >
                 <RefreshCw
                   className={`mr-1.5 h-3.5 w-3.5 ${isRegenerating ? "animate-spin" : ""}`}
                 />
-                再生成
+                {isRegenerating ? "再生成中..." : "AI 要約を再生成"}
               </Button>
             </div>
           </div>
         )}
+
+        {/* まだ snsDraft が無い場合でも再生成ボタンだけ出したい場合は、ここに fallback を追加できます */}
+        {!event.snsDraft && (
+          <div className="flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={summarize}
+              disabled={isRegenerating}
+              className="hover:bg-foreground hover:text-background h-9 bg-transparent text-xs transition-all"
+            >
+              <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isRegenerating ? "animate-spin" : ""}`} />
+              {isRegenerating ? "再生成中..." : "AI 要約を生成"}
+            </Button>
+          </div>
+        )}
       </CardContent>
     </Card>
-  );
+  )
 }

--- a/src/app/hooks/use-summarize.ts
+++ b/src/app/hooks/use-summarize.ts
@@ -1,0 +1,69 @@
+// src/app/hooks/use-summarize.ts
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { useToast } from "@/app/hooks/use-toast"
+
+type UseSummarizeOptions = {
+  githubEventId: string
+}
+
+export function useSummarize({ githubEventId }: UseSummarizeOptions) {
+  const [isLoading, setIsLoading] = useState(false)
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const summarize = async () => {
+    if (!githubEventId) return
+
+    setIsLoading(true)
+    try {
+      const res = await fetch("/api/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ githubEventId }),
+      })
+
+      if (!res.ok) {
+        let message = "AI 要約の生成に失敗しました。"
+
+        try {
+          const data = await res.json()
+          if (data?.error) message = data.error
+        } catch {
+          // JSON でないレスポンスは無視
+        }
+
+        toast({
+          variant: "destructive",
+          title: "要約生成エラー",
+          description: message,
+        })
+        return
+      }
+
+      const data = await res.json()
+      console.log("[ai/summarize] response:", data)
+
+      toast({
+        title: "AI 要約を生成しました",
+        description: "ダッシュボードの内容を更新しました。",
+      })
+
+      // DB の最新状態を反映
+      router.refresh()
+    } catch (error) {
+      console.error("[ai/summarize] failed:", error)
+      toast({
+        variant: "destructive",
+        title: "要約生成エラー",
+        description: "ネットワークエラーが発生しました。",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { summarize, isLoading }
+}


### PR DESCRIPTION
## 概要

- /dashboard の GitHubEvent カードから、AI 要約を生成・再生成できるようにしました。
- 既存の `/api/ai/summarize` をフロントから呼び出し、生成結果を SnsPost として保存 → ダッシュボードを再読み込みします。

## 変更内容

- `src/app/hooks/use-summarize.ts`
  - `/api/ai/summarize` を叩くカスタムフックを追加
  - ローディング状態・エラーハンドリング・トースト表示・`router.refresh()` を実装

- `src/app/components/github-event-card.tsx`
  - イベントごとに `useSummarize` を呼び出し、ボタンから AI 要約を実行できるように変更
  - 「AI 要約を生成 / 再生成」ボタンを追加
  - コピー処理とローディング状態を分けて扱うように微調整

## 動作確認

- [x] `/dashboard` にアクセスできる
- [x] 各 GitHubEvent カードで「AI 要約を生成」ボタンを押すと `/api/ai/summarize` が呼ばれる
- [x] 生成完了後、トースト表示され、ダッシュボードの内容が更新される
- [x] エラー時にトーストでエラー内容が表示される
- [x] 既存の GitHubEvent / SnsPost 表示が壊れていない
