### PR TITLE
feat: /dashboard から Webhook 送信を実行できるようにする

### DIFF
--- a/src/app/components/github-event-card.tsx
+++ b/src/app/components/github-event-card.tsx
@@ -1,12 +1,15 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { ExternalLink, Copy, RefreshCw, Send } from "lucide-react"
+
 import { Button } from "@/app/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/app/components/ui/card"
 import { StatusBadge } from "@/app/components/status-badge"
-import { ExternalLink, Copy, RefreshCw } from "lucide-react"
 import { useToast } from "@/app/hooks/use-toast"
 import { useSummarize } from "@/app/hooks/use-summarize"
+import { useSendWebhook } from "@/app/hooks/use-send-webhook"
 
 interface GithubEvent {
   id: string
@@ -16,35 +19,65 @@ interface GithubEvent {
   githubUrl: string
   mergedBy: string
   mergedAt: string
+
   status: "SUCCESS" | "FAILED" | "NONE"
+
   aiSummary?: string
   snsDraft?: string
+
+  // Webhook 送信用（※ここが入ってないと送信できない）
+  snsPostId?: string
+  snsStatus?: "SUCCESS" | "FAILED" | "PENDING"
 }
 
 export function GithubEventCard({ event }: { event: GithubEvent }) {
+  const router = useRouter()
   const { toast } = useToast()
   const [isCopying, setIsCopying] = useState(false)
 
-  // ここでフック呼び出し
+  // AI 要約 再生成
   const { summarize, isLoading: isRegenerating } = useSummarize({
     githubEventId: event.id,
+  })
+
+  // Webhook 送信（snsPostId を送る想定）
+  const { send, isSending } = useSendWebhook({
+    onSuccess: () => {
+      toast({ description: "Webhook に送信しました" })
+      router.refresh()
+    },
+    onError: (message) => {
+      toast({
+        variant: "destructive",
+        description: `送信に失敗しました: ${message}`,
+      })
+      router.refresh()
+    },
   })
 
   const handleCopy = async (text: string) => {
     try {
       setIsCopying(true)
       await navigator.clipboard.writeText(text)
-      toast({
-        description: "テキストをコピーしました",
-      })
+      toast({ description: "テキストをコピーしました" })
     } catch {
-      toast({
-        variant: "destructive",
-        description: "コピーに失敗しました",
-      })
+      toast({ variant: "destructive", description: "コピーに失敗しました" })
     } finally {
       setIsCopying(false)
     }
+  }
+
+  const handleSendWebhook = async () => {
+    if (!event.snsPostId) {
+      toast({
+        variant: "destructive",
+        description: "送信対象の SnsPost が見つかりません（snsPostId が未設定）",
+      })
+      return
+    }
+
+    // ✅ ここがポイント：string を渡す
+    await send(event.snsPostId)
   }
 
   return (
@@ -56,17 +89,21 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
               <h3 className="text-muted-foreground font-mono text-xs">{event.repository}</h3>
               <span className="text-muted-foreground/70 font-mono text-xs">#{event.prNumber}</span>
             </div>
+
             <h2 className="text-foreground text-base leading-snug font-semibold text-balance">
               {event.prTitle}
             </h2>
+
             <div className="text-muted-foreground flex items-center gap-3 text-xs">
               <span className="font-medium">{event.mergedBy}</span>
               <span className="opacity-50">•</span>
               <time>{event.mergedAt}</time>
             </div>
           </div>
-          <div className="flex flex-shrink-0 flex-col items-end gap-2.5">
+
+          <div className="flex shrink-0 flex-col items-end gap-2.5">
             <StatusBadge status={event.status} />
+
             <Button
               variant="outline"
               size="sm"
@@ -93,7 +130,7 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
             <h4 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
               AI 要約
             </h4>
-            <div className="bg-muted/30 border-border/50 text-foreground/90 rounded-lg border p-4 text-sm leading-relaxed">
+            <div className="border-border/50 bg-muted/30 text-foreground/90 rounded-lg border p-4 text-sm leading-relaxed">
               {event.aiSummary}
             </div>
           </div>
@@ -104,10 +141,12 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
             <h4 className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
               SNS 用ドラフト
             </h4>
+
             <div className="border-border/50 bg-card text-foreground/90 rounded-lg border p-4 font-mono text-sm leading-relaxed whitespace-pre-wrap">
               {event.snsDraft}
             </div>
-            <div className="flex gap-2">
+
+            <div className="flex flex-wrap gap-2">
               <Button
                 variant="outline"
                 size="sm"
@@ -118,6 +157,7 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
                 <Copy className="mr-1.5 h-3.5 w-3.5" />
                 {isCopying ? "コピー中..." : "コピー"}
               </Button>
+
               <Button
                 variant="outline"
                 size="sm"
@@ -130,11 +170,24 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
                 />
                 {isRegenerating ? "再生成中..." : "AI 要約を再生成"}
               </Button>
+
+              {/* ✅ snsPostId があるときだけ表示 */}
+              {event.snsPostId && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleSendWebhook}
+                  disabled={isSending}
+                  className="hover:bg-foreground hover:text-background h-9 bg-transparent text-xs transition-all"
+                >
+                  <Send className="mr-1.5 h-3.5 w-3.5" />
+                  {isSending ? "送信中..." : "Webhook送信"}
+                </Button>
+              )}
             </div>
           </div>
         )}
 
-        {/* まだ snsDraft が無い場合でも再生成ボタンだけ出したい場合は、ここに fallback を追加できます */}
         {!event.snsDraft && (
           <div className="flex justify-end">
             <Button
@@ -145,7 +198,7 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
               className="hover:bg-foreground hover:text-background h-9 bg-transparent text-xs transition-all"
             >
               <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isRegenerating ? "animate-spin" : ""}`} />
-              {isRegenerating ? "再生成中..." : "AI 要約を生成"}
+              {isRegenerating ? "生成中..." : "AI 要約を生成"}
             </Button>
           </div>
         )}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -22,10 +22,7 @@ export default async function DashboardPage() {
   const now = new Date()
   const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
 
-  // 直近7日間に作られたイベント
   const recentEvents = events.filter((e) => e.createdAt >= sevenDaysAgo && e.createdAt <= now)
-
-  // SnsPost 全体
   const allPosts = events.flatMap((e) => e.posts)
 
   const totalMergedLast7Days = recentEvents.length
@@ -37,7 +34,6 @@ export default async function DashboardPage() {
   return (
     <AppLayout>
       <div className="space-y-8">
-        {/* Header */}
         <div className="space-y-3">
           <h1 className="text-gradient text-3xl font-bold tracking-tight sm:text-4xl">
             ダッシュボード
@@ -47,14 +43,12 @@ export default async function DashboardPage() {
           </p>
         </div>
 
-        {/* Stats */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
           <StatsCard title="直近7日間のマージ数" value={totalMergedLast7Days} icon={GitMerge} />
           <StatsCard title="生成されたSNSドラフト数" value={totalSnsDrafts} icon={FileText} />
           <StatsCard title="失敗した生成数" value={totalFailed} icon={AlertCircle} />
         </div>
 
-        {/* Events */}
         <div className="space-y-5">
           <h2 className="text-foreground text-xl font-semibold tracking-tight sm:text-2xl">
             最近のイベント
@@ -70,9 +64,9 @@ export default async function DashboardPage() {
           ) : (
             <div className="space-y-4">
               {events.map((event) => {
+                // getDashboardEvents 側で posts は「最新1件のみ」にしている想定
                 const latestPost = event.posts[0] ?? null
 
-                // GithubEventCard が期待している形にマッピング
                 return (
                   <GithubEventCard
                     key={event.id}
@@ -84,9 +78,18 @@ export default async function DashboardPage() {
                       githubUrl: event.prUrl,
                       mergedBy: event.mergedBy ?? "unknown",
                       mergedAt: formatJpDate(event.createdAt),
+
+                      // status-badge 用（SnsPost が無ければ NONE）
                       status: (latestPost?.status as "SUCCESS" | "FAILED" | "NONE") ?? "NONE",
-                      aiSummary: latestPost?.content ?? "",
-                      snsDraft: latestPost?.content ?? "",
+
+                      // 表示用（空文字じゃなく undefined 推奨）
+                      aiSummary: latestPost?.content ?? undefined,
+                      snsDraft: latestPost?.content ?? undefined,
+
+                      // ★Webhook送信ボタン表示に必要
+                      snsPostId: latestPost?.id ?? undefined,
+                      snsStatus:
+                        (latestPost?.status as "SUCCESS" | "FAILED" | "PENDING") ?? undefined,
                     }}
                   />
                 )

--- a/src/app/hooks/use-send-webhook.ts
+++ b/src/app/hooks/use-send-webhook.ts
@@ -1,0 +1,42 @@
+"use client"
+
+import { useState } from "react"
+
+type Options = {
+  onSuccess?: () => void
+  onError?: (message: string) => void
+}
+
+export function useSendWebhook(options: Options = {}) {
+  const [isSending, setIsSending] = useState(false)
+
+  const send = async (snsPostId: string) => {
+    if (!snsPostId) return
+    setIsSending(true)
+
+    try {
+      const res = await fetch("/api/sns/post", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ snsPostId }),
+      })
+
+      const data = await res.json().catch(() => ({}))
+
+      if (!res.ok || data?.ok === false) {
+        const msg = data?.error || data?.snsPost?.errorMessage || `HTTP ${res.status}`
+        options.onError?.(msg)
+        return
+      }
+
+      options.onSuccess?.()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "unknown error"
+      options.onError?.(msg)
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  return { send, isSending }
+}


### PR DESCRIPTION
## 概要

/dashboard 上から SnsPost を Webhook に送信できるようにしました。

- Webhook送信ボタンを UI に追加
- 送信時に `/api/sns/post` を呼び出す
- 成功・失敗時にトースト表示
- 送信後に `router.refresh()` で最新状態を反映

フェーズ1として、UI からの送信フローを最小構成で実装しています。

---

## 実装内容

### UI
- `GithubEventCard` に「Webhook送信」ボタンを追加
- 送信中はボタンを disabled にする
- 送信完了後はダッシュボードを再取得

### Hook
- `use-send-webhook.ts` を新規追加
  - `/api/sns/post` を呼び出す責務を切り出し
  - 成功 / 失敗時のコールバックを受け取れる設計

### データ連携
- `/dashboard` 取得時に `SnsPost` 情報を含める
- `snsPostId` を UI に渡し、送信対象を特定

---

## 変更ファイル

- `src/app/components/github-event-card.tsx`
- `src/app/dashboard/page.tsx`
- `src/app/hooks/use-send-webhook.ts`（新規）

---

## 動作確認

1. `/dashboard` にアクセス
2. SNSドラフトが存在するイベントで「Webhook送信」ボタンが表示される
3. クリックすると Webhook に送信される
4. 成功 / 失敗のトーストが表示される
5. 画面がリフレッシュされる

---

## 補足 / 今後

- Webhook送信状態（SUCCESS / FAILED / PENDING）の UI 反映は別 Issue で対応予定
- 再送・エラーメッセージ表示も後続で実装予定
