### PR TITLE
feat: /dashboard に Webhook 送信状態を表示し更新を反映する

### DIFF
--- a/src/app/api/sns/post/route.ts
+++ b/src/app/api/sns/post/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/sns/post/route.ts
 import { NextRequest, NextResponse } from "next/server"
+import { revalidatePath } from "next/cache"
 import { prisma } from "@/server/db/client"
 
 export async function POST(req: NextRequest) {
@@ -8,13 +9,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "SNS_WEBHOOK_URL is not configured" }, { status: 500 })
   }
 
-  // body parse
-  const { snsPostId } = await req.json().catch(() => ({}))
+  console.log("[sns/post] SNS_WEBHOOK_URL =", webhookUrl)
+
+  const { snsPostId } = await req.json().catch(() => ({}) as { snsPostId?: string })
   if (!snsPostId) {
     return NextResponse.json({ error: "snsPostId is required" }, { status: 400 })
   }
 
-  // fetch post
   const snsPost = await prisma.snsPost.findUnique({
     where: { id: snsPostId },
     include: { event: true },
@@ -45,7 +46,7 @@ export async function POST(req: NextRequest) {
       body: JSON.stringify(payload),
     })
 
-    const text = await res.text()
+    const text = await res.text().catch(() => "")
 
     const updated = await prisma.snsPost.update({
       where: { id: snsPost.id },
@@ -55,7 +56,10 @@ export async function POST(req: NextRequest) {
       },
     })
 
-    return NextResponse.json({ ok: res.ok, snsPost: updated })
+    // ✅ /dashboard の表示キャッシュを破棄
+    revalidatePath("/dashboard")
+
+    return NextResponse.json({ ok: res.ok, snsPost: updated }, { status: res.ok ? 200 : 500 })
   } catch (e) {
     const message = e instanceof Error ? e.message : "unknown error"
 
@@ -67,6 +71,9 @@ export async function POST(req: NextRequest) {
       },
     })
 
-    return NextResponse.json({ error: message, snsPost: updated }, { status: 500 })
+    // ✅ 失敗時も /dashboard の表示キャッシュを破棄
+    revalidatePath("/dashboard")
+
+    return NextResponse.json({ ok: false, error: message, snsPost: updated }, { status: 500 })
   }
 }

--- a/src/app/components/github-event-card.tsx
+++ b/src/app/components/github-event-card.tsx
@@ -10,6 +10,10 @@ import { StatusBadge } from "@/app/components/status-badge"
 import { useToast } from "@/app/hooks/use-toast"
 import { useSummarize } from "@/app/hooks/use-summarize"
 import { useSendWebhook } from "@/app/hooks/use-send-webhook"
+import { cn } from "@/lib/utils"
+
+type AiStatus = "SUCCESS" | "FAILED" | "NONE"
+type WebhookStatus = "SUCCESS" | "FAILED" | "UNSENT"
 
 interface GithubEvent {
   id: string
@@ -20,14 +24,47 @@ interface GithubEvent {
   mergedBy: string
   mergedAt: string
 
-  status: "SUCCESS" | "FAILED" | "NONE"
+  // AI要約の状態（既存）
+  status: AiStatus
 
   aiSummary?: string
   snsDraft?: string
 
-  // Webhook 送信用（※ここが入ってないと送信できない）
+  // Webhook送信用
   snsPostId?: string
-  snsStatus?: "SUCCESS" | "FAILED" | "PENDING"
+  snsStatus?: WebhookStatus
+}
+
+function WebhookStatusBadge({ status }: { status: WebhookStatus }) {
+  const config: Record<WebhookStatus, { label: string; className: string }> = {
+    UNSENT: {
+      label: "未送信",
+      className: "bg-muted text-muted-foreground border-border",
+    },
+    SUCCESS: {
+      label: "送信済み",
+      className: "bg-emerald-500/10 text-emerald-700 border-emerald-500/30",
+    },
+    FAILED: {
+      label: "送信失敗",
+      className: "bg-destructive/10 text-destructive border-destructive/30",
+    },
+  }
+
+  const c = config[status]
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold",
+        c.className,
+      )}
+      aria-label={`Webhook送信状態: ${c.label}`}
+      title={`Webhook送信状態: ${c.label}`}
+    >
+      {c.label}
+    </span>
+  )
 }
 
 export function GithubEventCard({ event }: { event: GithubEvent }) {
@@ -40,7 +77,7 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
     githubEventId: event.id,
   })
 
-  // Webhook 送信（snsPostId を送る想定）
+  // Webhook 送信（snsPostId を送る）
   const { send, isSending } = useSendWebhook({
     onSuccess: () => {
       toast({ description: "Webhook に送信しました" })
@@ -75,10 +112,13 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
       })
       return
     }
-
-    // ✅ ここがポイント：string を渡す
     await send(event.snsPostId)
   }
+
+  // Webhook状態の表示は「snsPostId があるか」で決めるのが安全
+  // - snsPostId が無い = そもそも送る対象がないので未送信扱い
+  // - snsPostId がある = snsStatus が入る想定。無ければ未送信扱いに寄せる
+  const webhookStatus: WebhookStatus = event.snsPostId ? (event.snsStatus ?? "UNSENT") : "UNSENT"
 
   return (
     <Card className="group border-border/50 overflow-hidden transition-all duration-300 hover:-translate-y-1 hover:shadow-lg">
@@ -102,7 +142,11 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
           </div>
 
           <div className="flex shrink-0 flex-col items-end gap-2.5">
+            {/* AI要約の状態 */}
             <StatusBadge status={event.status} />
+
+            {/* ✅ Webhook送信状態（#14 の要件） */}
+            <WebhookStatusBadge status={webhookStatus} />
 
             <Button
               variant="outline"
@@ -150,8 +194,11 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => handleCopy(event.snsDraft!)}
-                disabled={isCopying}
+                onClick={() => {
+                  if (!event.snsDraft) return
+                  void handleCopy(event.snsDraft)
+                }}
+                disabled={isCopying || !event.snsDraft}
                 className="hover:bg-foreground hover:text-background h-9 text-xs transition-all"
               >
                 <Copy className="mr-1.5 h-3.5 w-3.5" />
@@ -171,7 +218,7 @@ export function GithubEventCard({ event }: { event: GithubEvent }) {
                 {isRegenerating ? "再生成中..." : "AI 要約を再生成"}
               </Button>
 
-              {/* ✅ snsPostId があるときだけ表示 */}
+              {/* snsPostId があるときだけ送信可能 */}
               {event.snsPostId && (
                 <Button
                   variant="outline"

--- a/src/app/dashboard/_components/refresh-button.tsx
+++ b/src/app/dashboard/_components/refresh-button.tsx
@@ -1,0 +1,13 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { Button } from "@/app/components/ui/button"
+
+export function RefreshButton() {
+  const router = useRouter()
+  return (
+    <Button variant="outline" size="sm" onClick={() => router.refresh()}>
+      更新
+    </Button>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,11 @@ import { GithubEventCard } from "@/app/components/github-event-card"
 import { EmptyState } from "@/app/components/empty-state"
 import { GitMerge, FileText, AlertCircle } from "lucide-react"
 import { getDashboardEvents } from "@/server/dashboard/getDashboardEvents"
+import { unstable_noStore as noStore } from "next/cache"
+import { RefreshButton } from "./_components/refresh-button"
+
+export const dynamic = "force-dynamic"
+export const revalidate = 0
 
 function formatJpDate(date: Date) {
   return date.toLocaleString("ja-JP", {
@@ -16,7 +21,13 @@ function formatJpDate(date: Date) {
   })
 }
 
+type UiStatus = "SUCCESS" | "FAILED" | "NONE"
+
+// ✅ GithubEventCard.tsx 側の snsStatus と合わせる（PENDINGは今回は扱わない）
+type WebhookStatusUi = "SUCCESS" | "FAILED" | "UNSENT" | undefined
+
 export default async function DashboardPage() {
+  noStore()
   const events = await getDashboardEvents()
 
   const now = new Date()
@@ -34,21 +45,27 @@ export default async function DashboardPage() {
   return (
     <AppLayout>
       <div className="space-y-8">
-        <div className="space-y-3">
-          <h1 className="text-gradient text-3xl font-bold tracking-tight sm:text-4xl">
-            ダッシュボード
-          </h1>
-          <p className="text-muted-foreground max-w-2xl text-sm leading-relaxed sm:text-base">
-            GitHub のマージ済み PR と AI の要約・SNSドラフトを一覧で確認できます
-          </p>
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-3">
+            <h1 className="text-gradient text-3xl font-bold tracking-tight sm:text-4xl">
+              ダッシュボード
+            </h1>
+            <p className="text-muted-foreground max-w-2xl text-sm leading-relaxed sm:text-base">
+              GitHub のマージ済み PR と AI の要約・SNSドラフトを一覧で確認できます
+            </p>
+          </div>
+          <RefreshButton />
         </div>
 
+        {/* Stats */}
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3">
           <StatsCard title="直近7日間のマージ数" value={totalMergedLast7Days} icon={GitMerge} />
           <StatsCard title="生成されたSNSドラフト数" value={totalSnsDrafts} icon={FileText} />
           <StatsCard title="失敗した生成数" value={totalFailed} icon={AlertCircle} />
         </div>
 
+        {/* Events */}
         <div className="space-y-5">
           <h2 className="text-foreground text-xl font-semibold tracking-tight sm:text-2xl">
             最近のイベント
@@ -64,8 +81,23 @@ export default async function DashboardPage() {
           ) : (
             <div className="space-y-4">
               {events.map((event) => {
-                // getDashboardEvents 側で posts は「最新1件のみ」にしている想定
                 const latestPost = event.posts[0] ?? null
+
+                const uiStatus: UiStatus =
+                  latestPost?.status === "SUCCESS"
+                    ? "SUCCESS"
+                    : latestPost?.status === "FAILED"
+                      ? "FAILED"
+                      : "NONE"
+
+                // ✅ Webhook表示は #14 スコープ通り（未送信/成功/失敗）
+                // PENDING が来ても未送信扱いに寄せる
+                const webhookStatus: WebhookStatusUi =
+                  latestPost?.status === "SUCCESS"
+                    ? "SUCCESS"
+                    : latestPost?.status === "FAILED"
+                      ? "FAILED"
+                      : undefined // ← UNSENT扱い（GithubEventCard側でUNSENT表示）
 
                 return (
                   <GithubEventCard
@@ -79,17 +111,13 @@ export default async function DashboardPage() {
                       mergedBy: event.mergedBy ?? "unknown",
                       mergedAt: formatJpDate(event.createdAt),
 
-                      // status-badge 用（SnsPost が無ければ NONE）
-                      status: (latestPost?.status as "SUCCESS" | "FAILED" | "NONE") ?? "NONE",
+                      status: uiStatus,
 
-                      // 表示用（空文字じゃなく undefined 推奨）
                       aiSummary: latestPost?.content ?? undefined,
                       snsDraft: latestPost?.content ?? undefined,
 
-                      // ★Webhook送信ボタン表示に必要
                       snsPostId: latestPost?.id ?? undefined,
-                      snsStatus:
-                        (latestPost?.status as "SUCCESS" | "FAILED" | "PENDING") ?? undefined,
+                      snsStatus: webhookStatus,
                     }}
                   />
                 )

--- a/src/server/dashboard/getDashboardEvents.ts
+++ b/src/server/dashboard/getDashboardEvents.ts
@@ -1,24 +1,25 @@
 // src/server/dashboard/getDashboardEvents.ts
 import { prisma } from "@/server/db/client"
-
-const OWNER_USER_ID = process.env.OWNER_USER_ID
+import { unstable_noStore as noStore } from "next/cache"
 
 export async function getDashboardEvents() {
+  // ✅ この関数の結果を Next のキャッシュ対象にしない
+  noStore()
+
+  // ✅ env は関数内で読む（開発中の反映・安全性のため）
+  const OWNER_USER_ID = process.env.OWNER_USER_ID
   if (!OWNER_USER_ID) {
     throw new Error("OWNER_USER_ID is not set. Please set OWNER_USER_ID in your .env file.")
   }
 
-  const events = await prisma.githubEvent.findMany({
+  return prisma.githubEvent.findMany({
     where: { userId: OWNER_USER_ID },
     include: {
       posts: {
-        orderBy: { createdAt: "desc" }, // 新しい順
+        orderBy: { createdAt: "desc" },
+        take: 1,
       },
     },
-    orderBy: {
-      createdAt: "desc",
-    },
+    orderBy: { createdAt: "desc" },
   })
-
-  return events
 }


### PR DESCRIPTION
## 概要
Webhook 送信（/api/sns/post）後に DB 更新はされているのに /dashboard の表示が更新されない問題があったため、
/dashboard を常に最新表示できるようにキャッシュ制御を追加し、Webhook 送信状態の UI 表示も追加しました。

## 変更点
- `/api/sns/post`
  - `revalidatePath("/dashboard")` を成功/失敗どちらでも実行するように追加
  - `res.text()` の例外を吸収し、レスポンス status を整理（成功:200 / 失敗:500）
- `/dashboard`
  - `dynamic = "force-dynamic"`, `revalidate = 0`, `noStore()` でキャッシュを回避
  - 手動更新用 `RefreshButton` を追加
- `GithubEventCard`
  - Webhook 送信状態（未送信/送信済み/送信失敗）を Badge で表示
- `getDashboardEvents`
  - `noStore()` 追加、`OWNER_USER_ID` を関数内で読む
  - posts は最新1件に統一（`orderBy desc + take:1`）

## 動作確認
- `SNS_WEBHOOK_URL` を無効URLにして curl 実行 → /dashboard リロードで「送信失敗」表示
- `SNS_WEBHOOK_URL` を有効URLにして curl 実行 → /dashboard リロードで「送信済み」表示
- RefreshButton で手動更新できること

## 影響範囲
/dashboard を動的表示にしているため、キャッシュによる高速化よりも「最新表示」を優先しています。
