### PR TITLE
feat: GitHub PRマージWebhook受信と重複防止を実装

### DIFF
--- a/prisma/migrations/20251215103750_npx_prisma_generate/migration.sql
+++ b/prisma/migrations/20251215103750_npx_prisma_generate/migration.sql
@@ -1,0 +1,31 @@
+/*
+  Warnings:
+
+  - Added the required column `githubDeliveryId` to the `GithubEvent` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_GithubEvent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "githubDeliveryId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "repoName" TEXT NOT NULL,
+    "prNumber" INTEGER NOT NULL,
+    "prTitle" TEXT NOT NULL,
+    "prUrl" TEXT NOT NULL,
+    "mergedBy" TEXT,
+    "rawPayload" JSONB NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GithubEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_GithubEvent" ("createdAt", "id", "mergedBy", "prNumber", "prTitle", "prUrl", "rawPayload", "repoName", "userId") SELECT "createdAt", "id", "mergedBy", "prNumber", "prTitle", "prUrl", "rawPayload", "repoName", "userId" FROM "GithubEvent";
+DROP TABLE "GithubEvent";
+ALTER TABLE "new_GithubEvent" RENAME TO "GithubEvent";
+CREATE UNIQUE INDEX "GithubEvent_githubDeliveryId_key" ON "GithubEvent"("githubDeliveryId");
+CREATE INDEX "GithubEvent_userId_createdAt_idx" ON "GithubEvent"("userId", "createdAt");
+CREATE INDEX "GithubEvent_repoName_prNumber_idx" ON "GithubEvent"("repoName", "prNumber");
+CREATE UNIQUE INDEX "GithubEvent_userId_repoName_prNumber_key" ON "GithubEvent"("userId", "repoName", "prNumber");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,16 +9,12 @@ datasource db {
 
 // ==================== Generator ====================
 generator client {
- provider = "prisma-client-js"
-  // Prisma Client を出力するパス
-  // （prisma ディレクトリからの相対パス）
-  output   = "../src/generated/prisma"
+  provider = "prisma-client-js"
 }
 
 // ==================== Models ====================
 
 // アプリ内ユーザー
-// フェーズ1ではオーナー1人のみだが、将来のSaaS化を見据えて定義
 model User {
   id        String        @id @default(cuid())
   name      String
@@ -29,27 +25,34 @@ model User {
 
 // GitHub から受け取った PR マージイベント
 model GithubEvent {
-  id         String       @id @default(cuid())
+  id              String       @id @default(cuid())
+
+  // ✅ GitHub Webhook の delivery ID（x-github-delivery）
+  // 同じ Webhook が再送されても同一IDになるため、これで二重保存を防止できる
+  githubDeliveryId String      @unique
 
   // マルチテナント対応用（フェーズ1では OWNER_USER_ID を入れる）
-  userId     String
-  user       User         @relation(fields: [userId], references: [id])
+  userId           String
+  user             User        @relation(fields: [userId], references: [id])
 
   // GitHub PR 情報
-  repoName   String       // 例: "kz2021019/docsnap"
-  prNumber   Int          // PR 番号 (#12 など)
-  prTitle    String
-  prUrl      String       // GitHub 上の PR URL
-  mergedBy   String?      // マージしたユーザー名 (login)。不明なら null
+  repoName         String       // 例: "kz2021019/docsnap"
+  prNumber         Int          // PR 番号 (#12 など)
+  prTitle          String
+  prUrl            String       // GitHub 上の PR URL
+  mergedBy         String?      // マージしたユーザー名 (login)。不明なら null
 
   // Webhook の payload 丸ごと
-  rawPayload Json
+  rawPayload       Json
 
-  createdAt  DateTime     @default(now())
+  createdAt        DateTime     @default(now())
 
-  posts      SnsPost[]
+  posts            SnsPost[]
+
+  @@unique([userId, repoName, prNumber])
 
   @@index([userId, createdAt])
+  @@index([repoName, prNumber])
 }
 
 // GitHub イベントをもとに行った SNS / Webhook 投稿ログ
@@ -62,8 +65,8 @@ model SnsPost {
   platform     String       // "webhook" | "x" | "bluesky" など
   content      String       // 実際に投稿した（しようとした）本文
   status       String       // "SUCCESS" | "FAILED" | "SKIPPED"
-  externalId   String?      // SNS 側の投稿ID等（なければ null）
-  errorMessage String?      // エラー時のメッセージ（正常時は null）
+  externalId   String?
+  errorMessage String?
 
   createdAt    DateTime     @default(now())
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,12 +2,29 @@
 import "dotenv/config"
 import { PrismaClient } from "@prisma/client"
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3"
+import { randomUUID } from "crypto"
 
 const adapter = new PrismaBetterSqlite3({
   url: process.env.DATABASE_URL || "file:./dev.db",
 })
 
 const prisma = new PrismaClient({ adapter })
+
+/**
+ * createdAt を安全にずらす（SQLiteでも安定して "最新" 判定させる）
+ */
+function minutesAgo(min: number) {
+  return new Date(Date.now() - min * 60 * 1000)
+}
+
+/**
+ * seed 用 deliveryId（@unique 必須）
+ * - GitHub 本番だと x-github-delivery が入る想定
+ * - seed は衝突しないよう UUID を使う
+ */
+function seedDeliveryId(label: string) {
+  return `seed-${label}-${randomUUID()}`
+}
 
 async function main() {
   // 1. User を準備（既存があればそれを使う）
@@ -39,10 +56,24 @@ async function main() {
 
   console.log("Seeding GithubEvent + SnsPost ...\n")
 
-  // 3. サンプルイベント + 投稿ログを複数件作成
+  /**
+   * 目的：
+   * - /dashboard のカードで Webhook 状態を確認できるようにする
+   *   - 未送信（webhook の post が無い）
+   *   - 送信済み（webhook の post が SUCCESS）
+   *   - 送信失敗（webhook の post が FAILED）
+   *
+   * 注意：
+   * - /dashboard は posts の「最新1件（take:1）」を見る設計なので
+   *   webhook 状態を見せたいカードでは webhook の post を "最新" にする必要がある
+   */
 
+  // -----------------------------
+  // A) 未送信：ai-preview だけ（webhook post なし）
+  // -----------------------------
   await prisma.githubEvent.create({
     data: {
+      githubDeliveryId: seedDeliveryId("unsent"), // ✅ 追加
       userId: user.id,
       repoName: "owner/repository-name",
       prNumber: 123,
@@ -55,6 +86,7 @@ async function main() {
         action: "closed",
         merged: true,
       },
+      createdAt: minutesAgo(60),
       posts: {
         create: [
           {
@@ -62,14 +94,19 @@ async function main() {
             content:
               "このPRでは、ユーザー認証システムを新たに実装しました。主な変更点として、JWTベースの認証機能、ログイン・ログアウトのエンドポイント、認証ミドルウェアを追加しています。また、ログインフォームのUIを改善し、エラーハンドリングを強化しました。",
             status: "SUCCESS",
+            createdAt: minutesAgo(59),
           },
         ],
       },
     },
   })
 
+  // -----------------------------
+  // B) 送信済み：webhook post を最新にする（SUCCESS）
+  // -----------------------------
   await prisma.githubEvent.create({
     data: {
+      githubDeliveryId: seedDeliveryId("success"),
       userId: user.id,
       repoName: "owner/api-server",
       prNumber: 87,
@@ -82,21 +119,37 @@ async function main() {
         action: "closed",
         merged: true,
       },
+      createdAt: minutesAgo(40),
       posts: {
         create: [
+          // 先に ai-preview（古い）
           {
             platform: "ai-preview",
             content:
               "データベース接続が失敗した際のエラーハンドリングを改善しました。リトライロジックを追加し、接続プールの設定を最適化しています。これにより、一時的なネットワークエラーに対する耐性が向上しました。",
             status: "SUCCESS",
+            createdAt: minutesAgo(39),
+          },
+          // 次に webhook（新しい＝最新1件）
+          {
+            platform: "webhook",
+            content: "Webhook送信済みテスト：DB接続エラーのハンドリング改善を反映しました。",
+            status: "SUCCESS",
+            externalId: "seed-success-001",
+            errorMessage: null,
+            createdAt: minutesAgo(38),
           },
         ],
       },
     },
   })
 
+  // -----------------------------
+  // C) 送信失敗：webhook post を最新にする（FAILED）
+  // -----------------------------
   await prisma.githubEvent.create({
     data: {
+      githubDeliveryId: seedDeliveryId("failed"), // ✅ 追加
       userId: user.id,
       repoName: "owner/frontend-app",
       prNumber: 234,
@@ -109,14 +162,25 @@ async function main() {
         action: "closed",
         merged: true,
       },
+      createdAt: minutesAgo(20),
       posts: {
         create: [
+          // ai-preview（古い）
           {
             platform: "ai-preview",
             content:
               "画像の遅延読み込み機能を実装し、初期ページ読み込み時のパフォーマンスを大幅に改善しました。Intersection Observer APIを使用し、ビューポートに入った画像のみを読み込むように変更しています。",
+            status: "SUCCESS",
+            createdAt: minutesAgo(19),
+          },
+          // webhook（新しい＝最新1件、FAILED）
+          {
+            platform: "webhook",
+            content: "Webhook送信失敗テスト：画像遅延読み込み実装の投稿を試行しました。",
             status: "FAILED",
-            errorMessage: "一時的な AI API エラーにより再試行が必要です。",
+            externalId: null,
+            errorMessage: "fetch failed（seed用の疑似エラー）",
+            createdAt: minutesAgo(18),
           },
         ],
       },

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -1,7 +1,7 @@
-// src/app/api/github/webhook/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/server/db/client"
 import { verifyGithubSignature } from "@/lib/github/verifySignature"
+import { revalidatePath } from "next/cache"
 
 type PullRequestMergedPayload = {
   action: string
@@ -12,9 +12,7 @@ type PullRequestMergedPayload = {
     merged: boolean
     merged_by: { login: string } | null
   }
-  repository: {
-    full_name: string // "owner/repo"
-  }
+  repository: { full_name: string }
 }
 
 export async function POST(req: NextRequest) {
@@ -28,41 +26,33 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  // ここで存在チェック（P2003 を避ける）
-  const ownerUser = await prisma.user.findUnique({
-    where: { id: ownerUserId },
-  })
-
+  // owner user exists?（P2003回避）
+  const ownerUser = await prisma.user.findUnique({ where: { id: ownerUserId } })
   if (!ownerUser) {
-    console.error("[github-webhook] OWNER_USER_ID user not found", {
-      ownerUserId,
-    })
-    return NextResponse.json(
-      { error: "Owner user not found for OWNER_USER_ID" },
-      { status: 500 },
-    )
+    console.error("[github-webhook] OWNER_USER_ID user not found", { ownerUserId })
+    return NextResponse.json({ error: "Owner user not found" }, { status: 500 })
   }
 
+  // delivery id（重複対策の主キー）
+  const deliveryId = req.headers.get("x-github-delivery")
+  if (!deliveryId) {
+    return NextResponse.json({ error: "Missing x-github-delivery header" }, { status: 400 })
+  }
+
+  const eventName = req.headers.get("x-github-event")
   const signature256 = req.headers.get("x-hub-signature-256")
-  const event = req.headers.get("x-github-event") // "pull_request" など
   const rawBody = await req.text()
 
+  // prod: 署名検証
   const isDev = process.env.NODE_ENV !== "production"
-
   if (!isDev) {
-    const valid = verifyGithubSignature({
-      secret,
-      payload: rawBody,
-      signature256,
-    })
+    const valid = verifyGithubSignature({ secret, payload: rawBody, signature256 })
+    if (!valid) return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+  }
 
-    if (!valid) {
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
-    }
-  } else {
-    console.log("[github-webhook] skip signature validation in dev", {
-      signature256,
-    })
+  // pull_request 以外は無視
+  if (eventName !== "pull_request") {
+    return NextResponse.json({ ok: true, ignored: true, reason: "not pull_request" })
   }
 
   let payload: PullRequestMergedPayload
@@ -72,19 +62,34 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
   }
 
-  if (event !== "pull_request") {
-    return NextResponse.json({ ok: true, ignored: true })
-  }
-
   const { action, pull_request, repository } = payload
 
+  // ✅ マージ以外は保存しない
   if (action !== "closed" || !pull_request.merged) {
-    return NextResponse.json({ ok: true, ignored: true })
+    return NextResponse.json({ ok: true, ignored: true, reason: "not merged PR" })
   }
 
+  // ✅ 二重防止1: deliveryId が同一なら即終了
+  const already = await prisma.githubEvent.findUnique({
+    where: { githubDeliveryId: deliveryId },
+    select: { id: true },
+  })
+  if (already) {
+    return NextResponse.json({ ok: true, duplicated: true, id: already.id })
+  }
+
+  // ✅ 二重防止2: 同じPRは upsert で1件に収束（@@unique([userId, repoName, prNumber]) が必要）
   try {
-    const created = await prisma.githubEvent.create({
-      data: {
+    const saved = await prisma.githubEvent.upsert({
+      where: {
+        userId_repoName_prNumber: {
+          userId: ownerUserId,
+          repoName: repository.full_name,
+          prNumber: pull_request.number,
+        },
+      },
+      create: {
+        githubDeliveryId: deliveryId,
         userId: ownerUserId,
         repoName: repository.full_name,
         prNumber: pull_request.number,
@@ -93,11 +98,21 @@ export async function POST(req: NextRequest) {
         mergedBy: pull_request.merged_by?.login ?? null,
         rawPayload: payload as unknown as object,
       },
+      update: {
+        prTitle: pull_request.title,
+        prUrl: pull_request.html_url,
+        mergedBy: pull_request.merged_by?.login ?? null,
+        rawPayload: payload as unknown as object,
+        // githubDeliveryId は unique なので update しない
+      },
     })
 
-    return NextResponse.json({ ok: true, id: created.id })
-  } catch (e) {
-    console.error("[github-webhook] failed to create event", e)
+    // ✅ ダッシュボード更新
+    revalidatePath("/dashboard")
+
+    return NextResponse.json({ ok: true, id: saved.id })
+  } catch (err) {
+    console.error("[github-webhook] failed to upsert event", err)
     return NextResponse.json({ error: "Failed to save event" }, { status: 500 })
   }
 }


### PR DESCRIPTION
## 概要

GitHub の Pull Request が **マージされた際に Webhook を受信し、
イベント情報を保存する仕組み**を実装しました。

Webhook の再送や二重通知を考慮し、**DB・アプリ両面での重複防止**を行っています。

---

## 対応内容

### GitHub Webhook 受信
- `pull_request` イベントのみを対象
- `action: closed` かつ `merged: true` の場合のみ保存

### 重複防止ロジック
- `x-github-delivery` を `githubDeliveryId` として保存（@unique）
- 同一 PR は  
  `userId + repoName + prNumber` の複合ユニーク制約で 1 件に集約
- `upsert` により再送時は既存レコードを更新

### DB / Prisma
- `GithubEvent` に以下を追加
  - `githubDeliveryId`（@unique）
  - `@@unique([userId, repoName, prNumber])`
- インデックスを追加し検索性を向上

### Seed データ整備
- Webhook 状態を再現できる seed を追加
  - 未送信
  - 送信成功（SUCCESS）
  - 送信失敗（FAILED）

### その他
- Webhook 受信後に `/dashboard` を `revalidatePath` で再検証

---

## 関連 Issue

Closes #16

---

## 動作確認

- [ ] PR マージ時の Webhook を正常に受信できる
- [ ] 同一 `deliveryId` の再送で重複登録されない
- [ ] 同一 PR が複数回送信されても 1 レコードに収束する
- [ ] `/dashboard` に最新状態が反映される

---

## 補足

フェーズ1では単一ユーザー（`OWNER_USER_ID`）前提ですが、
将来的なマルチテナント対応を考慮した設計になっています。
