### PR TITLE
feat: persist PR merge info (mergedBy/mergedAt/mergeCommitSha)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier . --check",
     "format:fix": "prettier . --write",
-    "prisma:seed": "ts-node prisma/seed.ts",
+    "prisma:seed": "ts-node --esm prisma/seed.ts",
     "typecheck": "tsc --noEmit",
     "prisma:backfill:delivery": "ts-node --esm prisma/backfill_github_delivery_id.ts"
   },

--- a/prisma/migrations/20251219224839_add_merge_info_columns/migration.sql
+++ b/prisma/migrations/20251219224839_add_merge_info_columns/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "GithubEvent" ADD COLUMN "mergeCommitSha" TEXT;
+ALTER TABLE "GithubEvent" ADD COLUMN "mergedAt" DATETIME;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,8 @@ model GithubEvent {
   prTitle          String
   prUrl            String       // GitHub 上の PR URL
   mergedBy         String?      // マージしたユーザー名 (login)。不明なら null
+  mergedAt         DateTime?
+  mergeCommitSha   String?
 
   // Webhook の payload 丸ごと
   rawPayload       Json

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,6 @@
 // prisma/seed.ts
 import "dotenv/config"
-import { PrismaClient } from "@prisma/client"
+import { PrismaClient, Prisma } from "@prisma/client"
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3"
 import { randomUUID } from "crypto"
 
@@ -23,36 +23,49 @@ function minutesAgo(min: number) {
  * - seed は衝突しないよう UUID を使う
  */
 function seedDeliveryId(label: string) {
+  // x-github-delivery は UUID 形式っぽいことが多いので寄せてもOK
   return `seed-${label}-${randomUUID()}`
 }
 
-async function main() {
-  // 1. User を準備（既存があればそれを使う）
-  let user = await prisma.user.findFirst()
+/**
+ * cuid運用で「Owner を必ず 1人」に寄せる。
+ * - OWNER_USER_ID があれば、その User を必ず使う（無ければ作らない・エラー）
+ * - OWNER_USER_ID が無ければ、既存 user がいればそれを使う / 無ければ作る
+ */
+async function resolveOwnerUser() {
+  const ownerUserId = process.env.OWNER_USER_ID
 
-  if (user) {
-    console.log("User already exists:")
-    console.log("id  :", user.id)
-    console.log("name:", user.name)
-  } else {
-    user = await prisma.user.create({
-      data: {
-        name: "Owner",
-      },
-    })
-
-    console.log("Created owner user:")
-    console.log("id  :", user.id)
-    console.log("name:", user.name)
+  if (ownerUserId) {
+    const owner = await prisma.user.findUnique({ where: { id: ownerUserId } })
+    if (!owner) {
+      throw new Error(`OWNER_USER_ID is set but user not found. OWNER_USER_ID="${ownerUserId}"`)
+    }
+    return owner
   }
 
-  console.log("\nYou can set OWNER_USER_ID in .env as:")
-  console.log(`OWNER_USER_ID="${user.id}"`)
+  // OWNER_USER_ID 未指定なら既存の先頭を使う（なければ作る）
+  const existing = await prisma.user.findFirst({ orderBy: { createdAt: "asc" } })
+  if (existing) return existing
 
-  // 2. 既存のイベント＆投稿ログを一旦クリアしてクリーンな状態にする
-  console.log("\nClearing existing events/posts for this user ...")
-  await prisma.snsPost.deleteMany({ where: { event: { userId: user.id } } })
-  await prisma.githubEvent.deleteMany({ where: { userId: user.id } })
+  return prisma.user.create({
+    data: { name: "Owner" },
+  })
+}
+
+async function main() {
+  const owner = await resolveOwnerUser()
+
+  console.log("Owner user:")
+  console.log("id  :", owner.id)
+  console.log("name:", owner.name)
+
+  console.log("\nSet OWNER_USER_ID in .env as:")
+  console.log(`OWNER_USER_ID="${owner.id}"`)
+
+  // 既存のイベント＆投稿ログを一旦クリアしてクリーンな状態にする（Owner分だけ）
+  console.log("\nClearing existing events/posts for this owner ...")
+  await prisma.snsPost.deleteMany({ where: { event: { userId: owner.id } } })
+  await prisma.githubEvent.deleteMany({ where: { userId: owner.id } })
 
   console.log("Seeding GithubEvent + SnsPost ...\n")
 
@@ -68,24 +81,32 @@ async function main() {
    *   webhook 状態を見せたいカードでは webhook の post を "最新" にする必要がある
    */
 
+  // ※ mergedAt / mergeCommitSha は Issue #22 に合わせて seed にも入れておく
+  //    （本番では GitHub webhook payload から入る）
+
   // -----------------------------
   // A) 未送信：ai-preview だけ（webhook post なし）
   // -----------------------------
   await prisma.githubEvent.create({
     data: {
-      githubDeliveryId: seedDeliveryId("unsent"), // ✅ 追加
-      userId: user.id,
+      githubDeliveryId: seedDeliveryId("unsent"),
+      userId: owner.id,
       repoName: "owner/repository-name",
       prNumber: 123,
       prTitle: "新機能: ユーザー認証システムの実装と UI の改善",
       prUrl: "https://github.com/owner/repository-name/pull/123",
       mergedBy: "tanaka-taro",
+      mergedAt: minutesAgo(70),
+      mergeCommitSha: `seed-unsent-${randomUUID().replace(/-/g, "")}`,
       rawPayload: {
         sample: true,
         type: "pull_request",
         action: "closed",
         merged: true,
-      },
+        merged_by: { login: "tanaka-taro" },
+        merged_at: minutesAgo(70).toISOString(),
+        merge_commit_sha: "seed-unsent",
+      } satisfies Prisma.InputJsonValue,
       createdAt: minutesAgo(60),
       posts: {
         create: [
@@ -107,18 +128,23 @@ async function main() {
   await prisma.githubEvent.create({
     data: {
       githubDeliveryId: seedDeliveryId("success"),
-      userId: user.id,
+      userId: owner.id,
       repoName: "owner/api-server",
       prNumber: 87,
       prTitle: "バグ修正: データベース接続エラーのハンドリング",
       prUrl: "https://github.com/owner/api-server/pull/87",
       mergedBy: "suzuki-hanako",
+      mergedAt: minutesAgo(50),
+      mergeCommitSha: `seed-success-${randomUUID().replace(/-/g, "")}`,
       rawPayload: {
         sample: true,
         type: "pull_request",
         action: "closed",
         merged: true,
-      },
+        merged_by: { login: "suzuki-hanako" },
+        merged_at: minutesAgo(50).toISOString(),
+        merge_commit_sha: "seed-success",
+      } satisfies Prisma.InputJsonValue,
       createdAt: minutesAgo(40),
       posts: {
         create: [
@@ -149,19 +175,24 @@ async function main() {
   // -----------------------------
   await prisma.githubEvent.create({
     data: {
-      githubDeliveryId: seedDeliveryId("failed"), // ✅ 追加
-      userId: user.id,
+      githubDeliveryId: seedDeliveryId("failed"),
+      userId: owner.id,
       repoName: "owner/frontend-app",
       prNumber: 234,
       prTitle: "パフォーマンス改善: 画像の遅延読み込みを実装",
       prUrl: "https://github.com/owner/frontend-app/pull/234",
       mergedBy: "yamada-ichiro",
+      mergedAt: minutesAgo(30),
+      mergeCommitSha: `seed-failed-${randomUUID().replace(/-/g, "")}`,
       rawPayload: {
         sample: true,
         type: "pull_request",
         action: "closed",
         merged: true,
-      },
+        merged_by: { login: "yamada-ichiro" },
+        merged_at: minutesAgo(30).toISOString(),
+        merge_commit_sha: "seed-failed",
+      } satisfies Prisma.InputJsonValue,
       createdAt: minutesAgo(20),
       posts: {
         create: [

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/server/db/client"
 import { verifyGithubSignature } from "@/lib/github/verifySignature"
 import { revalidatePath } from "next/cache"
+import type { Prisma } from "@prisma/client"
 
 type PullRequestMergedPayload = {
   action: string
@@ -11,6 +12,8 @@ type PullRequestMergedPayload = {
     html_url: string
     merged: boolean
     merged_by: { login: string } | null
+    merged_at: string | null
+    merge_commit_sha: string | null
   }
   repository: { full_name: string }
 }
@@ -57,17 +60,22 @@ export async function POST(req: NextRequest) {
 
   let payload: PullRequestMergedPayload
   try {
-    payload = JSON.parse(rawBody)
+    payload = JSON.parse(rawBody) as PullRequestMergedPayload
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
   }
 
   const { action, pull_request, repository } = payload
 
-  // ✅ マージ以外は保存しない
+  // ✅ マージ以外は保存しない（方針どおり）
   if (action !== "closed" || !pull_request.merged) {
     return NextResponse.json({ ok: true, ignored: true, reason: "not merged PR" })
   }
+
+  // merge 情報
+  const mergedBy = pull_request.merged_by?.login ?? null
+  const mergedAt = pull_request.merged_at ? new Date(pull_request.merged_at) : null
+  const mergeCommitSha = pull_request.merge_commit_sha ?? null
 
   // ✅ 二重防止1: deliveryId が同一なら即終了
   const already = await prisma.githubEvent.findUnique({
@@ -95,21 +103,23 @@ export async function POST(req: NextRequest) {
         prNumber: pull_request.number,
         prTitle: pull_request.title,
         prUrl: pull_request.html_url,
-        mergedBy: pull_request.merged_by?.login ?? null,
-        rawPayload: payload as unknown as object,
+        mergedBy,
+        mergedAt,
+        mergeCommitSha,
+        rawPayload: payload as unknown as Prisma.InputJsonValue,
       },
       update: {
         prTitle: pull_request.title,
         prUrl: pull_request.html_url,
-        mergedBy: pull_request.merged_by?.login ?? null,
-        rawPayload: payload as unknown as object,
+        mergedBy,
+        mergedAt,
+        mergeCommitSha,
+        rawPayload: payload as unknown as Prisma.InputJsonValue,
         // githubDeliveryId は unique なので update しない
       },
     })
 
-    // ✅ ダッシュボード更新
     revalidatePath("/dashboard")
-
     return NextResponse.json({ ok: true, id: saved.id })
   } catch (err) {
     console.error("[github-webhook] failed to upsert event", err)


### PR DESCRIPTION
## 概要
【本番想定】PR の merge 情報（`mergedBy` / `mergedAt` / `mergeCommitSha`）を取得して `GithubEvent` に保存できるようにしました。（Issue #22）

- `GithubEvent` に merge 情報のカラムを追加
- GitHub Webhook（pull_request）受信時に、マージ済みPRなら merge 情報を保存
- seed にも merge 情報を入れて、DB だけで動作確認できるように対応

---

## 変更内容
### 1. Prisma / DB
- `GithubEvent` に以下を追加
  - `mergedAt DateTime?`
  - `mergeCommitSha String?`
- マイグレーション作成・適用済み

### 2. Webhook（/api/github/webhook）
- `pull_request` イベントのうち、`action === "closed" && pull_request.merged === true` のときのみ保存（方針どおり）
- 追加で保存する値
  - `mergedBy: pull_request.merged_by?.login ?? null`
  - `mergedAt: pull_request.merged_at ? new Date(pull_request.merged_at) : null`
  - `mergeCommitSha: pull_request.merge_commit_sha ?? null`
- `rawPayload` は `Prisma.InputJsonValue` として保存

### 3. seed
- seedデータにも `mergedAt / mergeCommitSha` を入れて、DB確認だけで動作を追えるように対応

---

## 動作確認
- マイグレーション/生成
  - `npx prisma migrate dev`
  - `npx prisma generate`
- seed
  - `npm run prisma:seed`
- DB 確認（例）
  - `sqlite3 dev.db "SELECT repoName, prNumber, mergedBy, mergedAt, mergeCommitSha FROM GithubEvent ORDER BY createdAt DESC LIMIT 5;"`

---

## 関連Issue
- #22 【本番想定】PR の merge 情報（mergedBy / mergedAt / mergeCommitSha）を取得して保存する
