### PR TITLE
feat: add webhook delivery log for idempotency (#24)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2",
+  "language": "en,ja",
+  "dictionaries": ["softwareTerms", "typescript", "node"],
+  "words": [
+    "cuid",
+    "docsnap",
+    "revalidate",
+    "webhook",
+    "idempotency",
+    "deliveryid",
+    "githubdeliveryid"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/.next/**",
+    "**/dist/**",
+    "**/build/**",
+    "prisma/migrations/**",
+    "dev.db",
+    "dev.db-*"
+  ]
+}

--- a/prisma/migrations/20251220213819_add_webhook_delivery_log/migration.sql
+++ b/prisma/migrations/20251220213819_add_webhook_delivery_log/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "GithubWebhookDelivery" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "deliveryId" TEXT NOT NULL,
+    "eventName" TEXT NOT NULL,
+    "signature256" TEXT,
+    "receivedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "githubEventId" TEXT,
+    "rawPayload" JSONB NOT NULL,
+    CONSTRAINT "GithubWebhookDelivery_githubEventId_fkey" FOREIGN KEY ("githubEventId") REFERENCES "GithubEvent" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GithubWebhookDelivery_deliveryId_key" ON "GithubWebhookDelivery"("deliveryId");
+
+-- CreateIndex
+CREATE INDEX "GithubWebhookDelivery_eventName_receivedAt_idx" ON "GithubWebhookDelivery"("eventName", "receivedAt");
+
+-- CreateIndex
+CREATE INDEX "GithubWebhookDelivery_githubEventId_idx" ON "GithubWebhookDelivery"("githubEventId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,60 +16,90 @@ generator client {
 
 // アプリ内ユーザー
 model User {
-  id        String        @id @default(cuid())
+  id        String   @id @default(cuid())
   name      String
-  createdAt DateTime      @default(now())
+  createdAt DateTime @default(now())
 
-  events    GithubEvent[]
+  events GithubEvent[]
 }
 
 // GitHub から受け取った PR マージイベント
 model GithubEvent {
-  id              String       @id @default(cuid())
+  id String @id @default(cuid())
 
   // ✅ GitHub Webhook の delivery ID（x-github-delivery）
   // 同じ Webhook が再送されても同一IDになるため、これで二重保存を防止できる
   githubDeliveryId String @unique
+
   // マルチテナント対応用（フェーズ1では OWNER_USER_ID を入れる）
-  userId           String
-  user             User        @relation(fields: [userId], references: [id])
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
 
   // GitHub PR 情報
-  repoName         String       // 例: "kz2021019/docsnap"
-  prNumber         Int          // PR 番号 (#12 など)
-  prTitle          String
-  prUrl            String       // GitHub 上の PR URL
-  mergedBy         String?      // マージしたユーザー名 (login)。不明なら null
-  mergedAt         DateTime?
-  mergeCommitSha   String?
+  repoName       String // 例: "kz2021019/docsnap"
+  prNumber       Int // PR 番号 (#12 など)
+  prTitle        String
+  prUrl          String // GitHub 上の PR URL
+  mergedBy       String? // マージしたユーザー名 (login)。不明なら null
+  mergedAt       DateTime?
+  mergeCommitSha String?
 
   // Webhook の payload 丸ごと
-  rawPayload       Json
+  rawPayload Json
 
-  createdAt        DateTime     @default(now())
+  createdAt DateTime @default(now())
 
-  posts            SnsPost[]
+  posts SnsPost[]
 
+  // ✅ 逆側（GithubWebhookDelivery とのリレーション）
+  webhookDeliveries GithubWebhookDelivery[]
+
+  // 同一PRの収束用（owner + repo + prNumber）
   @@unique([userId, repoName, prNumber])
-
   @@index([userId, createdAt])
   @@index([repoName, prNumber])
 }
 
+// ✅ Webhook 受信ログ（冪等性の本体）
+model GithubWebhookDelivery {
+  id String @id @default(cuid())
+
+  // x-github-delivery（冪等性キー）
+  deliveryId String @unique
+
+  // x-github-event（例: pull_request）
+  eventName String
+
+  // x-hub-signature-256（prodのみ検証するが、保存しておくと調査が楽）
+  signature256 String?
+
+  receivedAt DateTime @default(now())
+
+  // この delivery が最終的に紐づいた GithubEvent（任意）
+  githubEventId String?
+  githubEvent   GithubEvent? @relation(fields: [githubEventId], references: [id])
+
+  // 調査用に payload を保持
+  rawPayload Json
+
+  @@index([eventName, receivedAt])
+  @@index([githubEventId])
+}
+
 // GitHub イベントをもとに行った SNS / Webhook 投稿ログ
 model SnsPost {
-  id           String       @id @default(cuid())
+  id String @id @default(cuid())
 
-  eventId      String
-  event        GithubEvent  @relation(fields: [eventId], references: [id])
+  eventId String
+  event   GithubEvent @relation(fields: [eventId], references: [id])
 
-  platform     String       // "webhook" | "x" | "bluesky" など
-  content      String       // 実際に投稿した（しようとした）本文
-  status       String       // "SUCCESS" | "FAILED" | "SKIPPED"
+  platform     String // "webhook" | "x" | "bluesky" など
+  content      String // 実際に投稿した（しようとした）本文
+  status       String // "SUCCESS" | "FAILED" | "SKIPPED"
   externalId   String?
   errorMessage String?
 
-  createdAt    DateTime     @default(now())
+  createdAt DateTime @default(now())
 
   @@index([eventId, createdAt])
 }

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/server/db/client"
 import { verifyGithubSignature } from "@/lib/github/verifySignature"
 import { revalidatePath } from "next/cache"
-import type { Prisma } from "@prisma/client"
+import { Prisma } from "@prisma/client"
 
 type PullRequestMergedPayload = {
   action: string
@@ -36,28 +36,63 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Owner user not found" }, { status: 500 })
   }
 
-  // delivery id（重複対策の主キー）
+  // headers
   const deliveryId = req.headers.get("x-github-delivery")
   if (!deliveryId) {
     return NextResponse.json({ error: "Missing x-github-delivery header" }, { status: 400 })
   }
 
-  const eventName = req.headers.get("x-github-event")
+  const eventName = req.headers.get("x-github-event") ?? "unknown"
   const signature256 = req.headers.get("x-hub-signature-256")
+
+  // raw body
   const rawBody = await req.text()
 
   // prod: 署名検証
   const isDev = process.env.NODE_ENV !== "production"
   if (!isDev) {
     const valid = verifyGithubSignature({ secret, payload: rawBody, signature256 })
-    if (!valid) return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+    if (!valid) {
+      // 署名NGはログ残すかは好み。残したいならここでも create を試してOK。
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+    }
   }
 
-  // pull_request 以外は無視
+  // ---- ここが “強い冪等性” の本体（insert-first） ----
+  let deliveryLogId: string | null = null
+  try {
+    const created = await prisma.githubWebhookDelivery.create({
+      data: {
+        deliveryId,
+        eventName,
+        signature256,
+        rawPayload: (() => {
+          try {
+            return JSON.parse(rawBody) as Prisma.InputJsonValue
+          } catch {
+            // JSON不正でも調査できるように文字列で残す（Json型に string は入る）
+            return rawBody as unknown as Prisma.InputJsonValue
+          }
+        })(),
+      },
+      select: { id: true },
+    })
+    deliveryLogId = created.id
+  } catch (e) {
+    // unique衝突 = 既に処理した deliveryId
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      return NextResponse.json({ ok: true, duplicated: true, deliveryId })
+    }
+    console.error("[github-webhook] failed to create delivery log", e)
+    return NextResponse.json({ error: "Failed to log delivery" }, { status: 500 })
+  }
+
+  // pull_request 以外は無視（ログは残っている）
   if (eventName !== "pull_request") {
     return NextResponse.json({ ok: true, ignored: true, reason: "not pull_request" })
   }
 
+  // JSON parse
   let payload: PullRequestMergedPayload
   try {
     payload = JSON.parse(rawBody) as PullRequestMergedPayload
@@ -67,7 +102,7 @@ export async function POST(req: NextRequest) {
 
   const { action, pull_request, repository } = payload
 
-  // ✅ マージ以外は保存しない（方針どおり）
+  // マージ以外は保存しない
   if (action !== "closed" || !pull_request.merged) {
     return NextResponse.json({ ok: true, ignored: true, reason: "not merged PR" })
   }
@@ -77,16 +112,7 @@ export async function POST(req: NextRequest) {
   const mergedAt = pull_request.merged_at ? new Date(pull_request.merged_at) : null
   const mergeCommitSha = pull_request.merge_commit_sha ?? null
 
-  // ✅ 二重防止1: deliveryId が同一なら即終了
-  const already = await prisma.githubEvent.findUnique({
-    where: { githubDeliveryId: deliveryId },
-    select: { id: true },
-  })
-  if (already) {
-    return NextResponse.json({ ok: true, duplicated: true, id: already.id })
-  }
-
-  // ✅ 二重防止2: 同じPRは upsert で1件に収束（@@unique([userId, repoName, prNumber]) が必要）
+  // upsert（同一PRは1件に収束）
   try {
     const saved = await prisma.githubEvent.upsert({
       where: {
@@ -117,12 +143,20 @@ export async function POST(req: NextRequest) {
         rawPayload: payload as unknown as Prisma.InputJsonValue,
         // githubDeliveryId は unique なので update しない
       },
+      select: { id: true },
+    })
+
+    // delivery log に紐付け（調査性UP）
+    await prisma.githubWebhookDelivery.update({
+      where: { id: deliveryLogId },
+      data: { githubEventId: saved.id },
     })
 
     revalidatePath("/dashboard")
     return NextResponse.json({ ok: true, id: saved.id })
   } catch (err) {
     console.error("[github-webhook] failed to upsert event", err)
+    // 失敗しても delivery log は残ってるので追跡できる
     return NextResponse.json({ error: "Failed to save event" }, { status: 500 })
   }
 }


### PR DESCRIPTION
## 概要
GitHub Webhook の冪等性を強化するため、`x-github-delivery` をキーに受信ログを保存する仕組みを追加しました。
同一 delivery の再送・多重送信が発生しても、DB への二重保存を防止します。

## 背景 / 課題（#24）
- GitHub Webhook は同一イベントが再送される可能性がある
- 既存は `GithubEvent.githubDeliveryId (@unique)` である程度防げるが、
  - 受信ログが残らない
  - どの delivery がどの event に紐づいたか追跡しづらい
  - 競合時の挙動を統一しづらい
- 本番想定で「冪等性の本体」を用意しておきたい

## 対応内容
### 1. Prisma: Webhook 受信ログモデル追加
- `GithubWebhookDelivery` モデルを追加
  - `deliveryId` を `@unique`（冪等性キー）
  - `eventName`, `signature256`, `receivedAt`, `rawPayload` を保存
  - `githubEventId`（任意）で `GithubEvent` と紐づけ可能

### 2. Prisma: 逆リレーション追加
- `GithubEvent.webhookDeliveries` を追加し、両方向の関連を定義

### 3. API: 冪等チェック強化
- 受信時に `deliveryId` でログを確認し、既に存在する場合は即 `duplicated: true` を返す
- 新規の場合のみ `GithubEvent` を upsert し、`GithubWebhookDelivery.githubEventId` を紐付ける

### 4. DX: cspell 対応
- `cspell.json` を追加/更新し、`cuid`, `docsnap` 等の警告を抑制

## 動作確認
### 単発（同一 delivery を2回送信）
- 1回目: `{"ok": true, "id": "..."}`
- 2回目: `{"ok": true, "duplicated": true, "deliveryId": "test-delivery-001"}`

確認SQL:
```bash
sqlite3 dev.db "SELECT COUNT(*) FROM GithubWebhookDelivery WHERE deliveryId='test-delivery-001';"
sqlite3 dev.db "SELECT COUNT(*) FROM GithubEvent WHERE githubDeliveryId='test-delivery-001';"
```
期待値: 両方 1

### 疑似レース（同一 delivery を並列10発）
```bash
for i in $(seq 1 10); do
  (curl -sS -X POST "$URL" \
    -H "content-type: application/json" \
    -H "x-github-event: pull_request" \
    -H "x-github-delivery: $DID" \
    --data "$payload" >/dev/null) &
done
wait
sqlite3 dev.db "SELECT COUNT(*) FROM GithubWebhookDelivery WHERE deliveryId='$DID';"
sqlite3 dev.db "SELECT COUNT(*) FROM GithubEvent WHERE githubDeliveryId='$DID';"
```
期待値: 両方 1

## 影響範囲
- DB に Webhook 受信ログテーブルが追加されます
- 既存の GithubEvent 保存ロジックは維持しつつ、冪等性チェックをより確実にします
- 既存の seed / dashboard 表示には影響なし（想定）

## 関連 Issue
- #24 【本番想定】Webhook idempotency（deliveryId で二重防止 + 受信ログ）