### PR TITLE
feat: Webhook冪等性ログに処理結果・再実行情報を追加（#26）

### DIFF
--- a/prisma/migrations/20251220225329_add_webhook_delivery_status/migration.sql
+++ b/prisma/migrations/20251220225329_add_webhook_delivery_status/migration.sql
@@ -1,0 +1,27 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_GithubWebhookDelivery" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "deliveryId" TEXT NOT NULL,
+    "eventName" TEXT NOT NULL,
+    "signature256" TEXT,
+    "receivedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL DEFAULT 'RECEIVED',
+    "attemptCount" INTEGER NOT NULL DEFAULT 0,
+    "lastAttemptAt" DATETIME,
+    "processedAt" DATETIME,
+    "errorMessage" TEXT,
+    "githubEventId" TEXT,
+    "rawPayload" JSONB NOT NULL,
+    CONSTRAINT "GithubWebhookDelivery_githubEventId_fkey" FOREIGN KEY ("githubEventId") REFERENCES "GithubEvent" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_GithubWebhookDelivery" ("deliveryId", "eventName", "githubEventId", "id", "rawPayload", "receivedAt", "signature256") SELECT "deliveryId", "eventName", "githubEventId", "id", "rawPayload", "receivedAt", "signature256" FROM "GithubWebhookDelivery";
+DROP TABLE "GithubWebhookDelivery";
+ALTER TABLE "new_GithubWebhookDelivery" RENAME TO "GithubWebhookDelivery";
+CREATE UNIQUE INDEX "GithubWebhookDelivery_deliveryId_key" ON "GithubWebhookDelivery"("deliveryId");
+CREATE INDEX "GithubWebhookDelivery_eventName_receivedAt_idx" ON "GithubWebhookDelivery"("eventName", "receivedAt");
+CREATE INDEX "GithubWebhookDelivery_githubEventId_idx" ON "GithubWebhookDelivery"("githubEventId");
+CREATE INDEX "GithubWebhookDelivery_status_receivedAt_idx" ON "GithubWebhookDelivery"("status", "receivedAt");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,16 @@ generator client {
   provider = "prisma-client-js"
 }
 
+// ==================== Enums ====================
+
+// ✅ Webhook 受信ログの処理ステータス
+enum WebhookDeliveryStatus {
+  RECEIVED // 受信してログは作った（処理前）
+  PROCESSED // 本処理まで成功
+  FAILED // 本処理が失敗
+  IGNORED // 対象外イベントなどで処理しなかった
+}
+
 // ==================== Models ====================
 
 // アプリ内ユーザー
@@ -73,7 +83,27 @@ model GithubWebhookDelivery {
   // x-hub-signature-256（prodのみ検証するが、保存しておくと調査が楽）
   signature256 String?
 
+  // ✅ 受信時刻（最初に受け取った時刻）
   receivedAt DateTime @default(now())
+
+  // =========================
+  // ✅ #25 追加: 処理結果・再実行用
+  // =========================
+
+  // 現在の状態
+  status WebhookDeliveryStatus @default(RECEIVED)
+
+  // 何回処理を試みたか（FAILEDの再送/再処理に備える）
+  attemptCount Int @default(0)
+
+  // 最後に処理を試みた時刻
+  lastAttemptAt DateTime?
+
+  // 処理が完了した時刻（PROCESSED / IGNORED のときに入れる想定）
+  processedAt DateTime?
+
+  // 失敗理由（FAILED のときに入れる）
+  errorMessage String?
 
   // この delivery が最終的に紐づいた GithubEvent（任意）
   githubEventId String?
@@ -84,6 +114,7 @@ model GithubWebhookDelivery {
 
   @@index([eventName, receivedAt])
   @@index([githubEventId])
+  @@index([status, receivedAt])
 }
 
 // GitHub イベントをもとに行った SNS / Webhook 投稿ログ

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -1,8 +1,10 @@
+// src/app/api/github/webhook/route.ts
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/server/db/client"
 import { verifyGithubSignature } from "@/lib/github/verifySignature"
 import { revalidatePath } from "next/cache"
 import { Prisma } from "@prisma/client"
+import type { WebhookDeliveryStatus } from "@prisma/client"
 
 type PullRequestMergedPayload = {
   action: string
@@ -16,6 +18,68 @@ type PullRequestMergedPayload = {
     merge_commit_sha: string | null
   }
   repository: { full_name: string }
+}
+
+function isKnownRequestError(e: unknown): e is Prisma.PrismaClientKnownRequestError {
+  return e instanceof Prisma.PrismaClientKnownRequestError
+}
+
+function shouldShortCircuit(status: WebhookDeliveryStatus) {
+  return status === "PROCESSED" || status === "IGNORED"
+}
+
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message
+  if (typeof err === "string") return err
+  try {
+    return JSON.stringify(err)
+  } catch {
+    return "unknown error"
+  }
+}
+
+/**
+ * delivery log を作成 or 既存取得（レース対策込み）
+ */
+async function findOrCreateDeliveryLog(params: {
+  deliveryId: string
+  eventName: string
+  signature256: string | null
+  rawPayload: Prisma.InputJsonValue
+}) {
+  const { deliveryId, eventName, signature256, rawPayload } = params
+
+  let delivery = await prisma.githubWebhookDelivery.findUnique({
+    where: { deliveryId },
+    select: { id: true, status: true, attemptCount: true, githubEventId: true },
+  })
+
+  if (delivery) return delivery
+
+  try {
+    delivery = await prisma.githubWebhookDelivery.create({
+      data: {
+        deliveryId,
+        eventName,
+        signature256,
+        rawPayload,
+        status: "RECEIVED",
+        attemptCount: 0,
+      },
+      select: { id: true, status: true, attemptCount: true, githubEventId: true },
+    })
+    return delivery
+  } catch (e) {
+    if (isKnownRequestError(e) && e.code === "P2002") {
+      // create レース → 取り直し
+      const again = await prisma.githubWebhookDelivery.findUnique({
+        where: { deliveryId },
+        select: { id: true, status: true, attemptCount: true, githubEventId: true },
+      })
+      if (again) return again
+    }
+    throw e
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -48,62 +112,120 @@ export async function POST(req: NextRequest) {
   // raw body
   const rawBody = await req.text()
 
-  // prod: 署名検証
-  const isDev = process.env.NODE_ENV !== "production"
-  if (!isDev) {
-    const valid = verifyGithubSignature({ secret, payload: rawBody, signature256 })
-    if (!valid) {
-      // 署名NGはログ残すかは好み。残したいならここでも create を試してOK。
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+  // rawPayload を “必ず” 何かしら残す（JSON不正でも文字列で残す）
+  const rawPayload: Prisma.InputJsonValue = (() => {
+    try {
+      return JSON.parse(rawBody) as Prisma.InputJsonValue
+    } catch {
+      return rawBody as unknown as Prisma.InputJsonValue
     }
-  }
+  })()
 
-  // ---- ここが “強い冪等性” の本体（insert-first） ----
-  let deliveryLogId: string | null = null
+  // =====================================================
+  // 1) delivery log を確実に作る / 既存を取得する
+  // =====================================================
+  let delivery
   try {
-    const created = await prisma.githubWebhookDelivery.create({
-      data: {
-        deliveryId,
-        eventName,
-        signature256,
-        rawPayload: (() => {
-          try {
-            return JSON.parse(rawBody) as Prisma.InputJsonValue
-          } catch {
-            // JSON不正でも調査できるように文字列で残す（Json型に string は入る）
-            return rawBody as unknown as Prisma.InputJsonValue
-          }
-        })(),
-      },
-      select: { id: true },
+    delivery = await findOrCreateDeliveryLog({
+      deliveryId,
+      eventName,
+      signature256,
+      rawPayload,
     })
-    deliveryLogId = created.id
   } catch (e) {
-    // unique衝突 = 既に処理した deliveryId
-    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
-      return NextResponse.json({ ok: true, duplicated: true, deliveryId })
-    }
     console.error("[github-webhook] failed to create delivery log", e)
     return NextResponse.json({ error: "Failed to log delivery" }, { status: 500 })
   }
 
-  // pull_request 以外は無視（ログは残っている）
+  // 完了済みは即終了
+  if (shouldShortCircuit(delivery.status)) {
+    return NextResponse.json({
+      ok: true,
+      duplicated: true,
+      deliveryId,
+      status: delivery.status,
+      githubEventId: delivery.githubEventId,
+      attemptCount: delivery.attemptCount,
+    })
+  }
+
+  // =====================================================
+  // 2) 今回の試行を記録（attemptCount++, lastAttemptAt, status=RECEIVED）
+  // =====================================================
+  await prisma.githubWebhookDelivery.update({
+    where: { deliveryId },
+    data: {
+      attemptCount: { increment: 1 },
+      lastAttemptAt: new Date(),
+      status: "RECEIVED",
+      errorMessage: null,
+      rawPayload,
+      eventName,
+      signature256,
+    },
+  })
+
+  // =====================================================
+  // 2.5) 署名検証（本番のみ）
+  // - 署名NGでも delivery log を FAILED にして残す（調査性を上げる）
+  // =====================================================
+  const isDev = process.env.NODE_ENV !== "production"
+  if (!isDev) {
+    const valid = verifyGithubSignature({ secret, payload: rawBody, signature256 })
+    if (!valid) {
+      await prisma.githubWebhookDelivery.update({
+        where: { deliveryId },
+        data: {
+          status: "FAILED",
+          processedAt: new Date(),
+          errorMessage: "Invalid signature",
+        },
+      })
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+    }
+  }
+
+  // =====================================================
+  // 3) 対象外イベント → IGNORED
+  // =====================================================
   if (eventName !== "pull_request") {
+    await prisma.githubWebhookDelivery.update({
+      where: { deliveryId },
+      data: {
+        status: "IGNORED",
+        processedAt: new Date(),
+      },
+    })
     return NextResponse.json({ ok: true, ignored: true, reason: "not pull_request" })
   }
 
-  // JSON parse
+  // JSON parse（pull_request として扱う）
   let payload: PullRequestMergedPayload
   try {
     payload = JSON.parse(rawBody) as PullRequestMergedPayload
   } catch {
+    await prisma.githubWebhookDelivery.update({
+      where: { deliveryId },
+      data: {
+        status: "FAILED",
+        processedAt: new Date(),
+        errorMessage: "Invalid JSON",
+      },
+    })
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
   }
 
   const { action, pull_request, repository } = payload
 
-  // マージ以外は保存しない
+  // マージ以外は保存しない → IGNORED
   if (action !== "closed" || !pull_request.merged) {
+    await prisma.githubWebhookDelivery.update({
+      where: { deliveryId },
+      data: {
+        status: "IGNORED",
+        processedAt: new Date(),
+      },
+    })
     return NextResponse.json({ ok: true, ignored: true, reason: "not merged PR" })
   }
 
@@ -112,7 +234,9 @@ export async function POST(req: NextRequest) {
   const mergedAt = pull_request.merged_at ? new Date(pull_request.merged_at) : null
   const mergeCommitSha = pull_request.merge_commit_sha ?? null
 
-  // upsert（同一PRは1件に収束）
+  // =====================================================
+  // 4) 本処理（GithubEvent upsert）→ 成功/失敗を delivery に反映
+  // =====================================================
   try {
     const saved = await prisma.githubEvent.upsert({
       where: {
@@ -141,22 +265,34 @@ export async function POST(req: NextRequest) {
         mergedAt,
         mergeCommitSha,
         rawPayload: payload as unknown as Prisma.InputJsonValue,
-        // githubDeliveryId は unique なので update しない
       },
       select: { id: true },
     })
 
-    // delivery log に紐付け（調査性UP）
     await prisma.githubWebhookDelivery.update({
-      where: { id: deliveryLogId },
-      data: { githubEventId: saved.id },
+      where: { deliveryId },
+      data: {
+        status: "PROCESSED",
+        processedAt: new Date(),
+        githubEventId: saved.id,
+      },
     })
 
     revalidatePath("/dashboard")
     return NextResponse.json({ ok: true, id: saved.id })
   } catch (err) {
+    const msg = toErrorMessage(err)
     console.error("[github-webhook] failed to upsert event", err)
-    // 失敗しても delivery log は残ってるので追跡できる
+
+    await prisma.githubWebhookDelivery.update({
+      where: { deliveryId },
+      data: {
+        status: "FAILED",
+        processedAt: new Date(),
+        errorMessage: msg,
+      },
+    })
+
     return NextResponse.json({ error: "Failed to save event" }, { status: 500 })
   }
 }


### PR DESCRIPTION
## 概要
Webhook 冪等性ログ（GithubWebhookDelivery）に「処理結果（PROCESSED/FAILED/IGNORED）」と「再実行（FAILED の再送で再処理）」を追加し、本番運用での追跡性・復旧性を高めました。 #26

## 背景
#24 で deliveryId 単位の冪等性（重複保存防止）は実現できていたが、
- 途中で失敗した delivery が再送されても duplicated 扱いで処理されない
- DB 上から失敗理由や再試行回数が追えない
という運用上のリスクが残っていました。

## 対応内容

### 1. DB（Prisma）
- `WebhookDeliveryStatus` enum を追加（RECEIVED / PROCESSED / FAILED / IGNORED）
- `GithubWebhookDelivery` に以下を追加
  - `status`
  - `attemptCount`
  - `lastAttemptAt`
  - `processedAt`
  - `errorMessage`
- インデックス追加（`status, receivedAt` 等）

### 2. Webhook route
- 受信 → ログ作成/取得 → attempt 記録 → 本処理 → 結果更新 を一貫化
- 冪等性判定ルール
  - 未登録: 通常処理
  - 既存かつ `PROCESSED|IGNORED`: duplicated で即終了
  - 既存かつ `FAILED|RECEIVED`: 再処理を許可し `attemptCount` を増やす
- エラー時は `FAILED + errorMessage` を記録
- 成功時は `PROCESSED + processedAt + githubEventId` を記録
- 対象外イベントは `IGNORED` を記録

## 受け入れ条件（#26）チェック
- [x] 同一 deliveryId を2回送っても `GithubWebhookDelivery` / `GithubEvent` は 1件に収束
- [x] 失敗時 `FAILED` + `errorMessage` が残る
- [x] `FAILED` の deliveryId を再送すると再処理され `attemptCount` が増える
- [x] 成功時 `PROCESSED` + `processedAt` + `githubEventId` が保存される
- [x] race（同時送信）でも 1件に収束
- [x] `prisma generate` / `typecheck` が通る

## 動作確認（curl / sqlite）
（手元で実施したケース）
- OK: `PROCESSED` / duplicated short-circuit
- IGNORED: ping event
- FAILED: invalid JSON → 再送で PROCESSED（attemptCount増加）
- RACE: 同一 deliveryId を並列10回送信 → 1件に収束

## 変更ファイル
- `prisma/schema.prisma`
- `prisma/migrations/20251220225329_add_webhook_delivery_status/`
- `src/app/api/github/webhook/route.ts`

## 補足
- Queue 化や管理UIは今回スコープ外（将来的に拡張予定）
