### PR TITLE
feat: GitHub Webhook の署名検証（X-Hub-Signature-256）を厳密化する #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,73 @@ npm run test
 ```
 
 test.db を使って Prisma を db push --force-reset し、API の integration test を実行する。
+
+## ローカルで GitHub Webhook を本番同様に確認する（ngrok + 署名検証）
+
+### 前提
+
+- `.env` に `GITHUB_WEBHOOK_SECRET`, `OWNER_USER_ID` を設定済み
+- `ngrok http 3000` で公開URLを取得済み（例: `https://xxxx.ngrok-free.app`）
+
+### 起動
+
+```bash
+npm run dev
+ngrok http 3000
+```
+
+### 署名付きで webhook を送る（推奨）
+
+```baash
+
+export NGROK_BASE="https://xxxx.ngrok-free.app"
+export GITHUB_WEBHOOK_SECRET="(your secret)"
+
+./scripts/webhook-send.sh ping ping-001 '{"zen":"hello"}'
+
+```
+
+### pull_request(merged) を送る
+
+```bash
+payload='{
+  "action":"closed",
+  "pull_request":{
+    "number":12345,
+    "title":"test",
+    "html_url":"https://github.com/owner/repo/pull/12345",
+    "merged":true,
+    "merged_by":{"login":"tester"},
+    "merged_at":"2025-12-21T00:00:00Z",
+    "merge_commit_sha":"sha"
+  },
+  "repository":{"full_name":"owner/repo"}
+}'
+
+./scripts/webhook-send.sh pull_request pr-001 "$payload"
+
+```
+
+### DB で結果確認
+
+```bash
+sqlite3 dev.db "
+SELECT deliveryId, eventName, status, attemptCount, errorMessage
+FROM GithubWebhookDelivery
+ORDER BY receivedAt DESC
+LIMIT 10;
+"
+
+sqlite3 dev.db "
+SELECT id, githubDeliveryId, repoName, prNumber, mergedBy, mergeCommitSha
+FROM GithubEvent
+ORDER BY mergedAt DESC
+LIMIT 10;
+"
+```
+
+### 署名エラーの期待挙動
+
+- x-hub-signature-256 が無い → 401 / reason=missing_header
+- secret が違う → 401 / reason=mismatch
+- いずれも GithubWebhookDelivery.status=FAILED に記録される

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitest/coverage-v8": "^4.0.16",
+        "dotenv-cli": "^11.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.0.7",
         "eslint-config-prettier": "^10.1.8",
@@ -8377,6 +8378,51 @@
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-11.0.0.tgz",
+      "integrity": "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.1.0",
+        "dotenv-expand": "^12.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-cli/node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "dotenv -e .env -- next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
@@ -13,7 +13,7 @@
     "prisma:seed": "ts-node --esm prisma/seed.ts",
     "typecheck": "tsc --noEmit",
     "prisma:backfill:delivery": "ts-node --esm prisma/backfill_github_delivery_id.ts",
-    "test": "vitest",
+    "test": "dotenv -e .env -- vitest",
     "test:run": "vitest run",
     "test:watch": "vitest"
   },
@@ -76,6 +76,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^4.0.16",
+    "dotenv-cli": "^11.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.0.7",
     "eslint-config-prettier": "^10.1.8",

--- a/scripts/webhook-send.sh
+++ b/scripts/webhook-send.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 使い方:
+#   set -a; source .env; set +a
+#   export NGROK_BASE="https://xxxx.ngrok-free.app"
+#
+#   ./scripts/webhook-send.sh ping my-delivery-id '{"zen":"hello"}'
+#
+#   payload='{
+#     "action":"closed",
+#     "pull_request":{
+#       "number":12400,
+#       "title":"signed pr via script",
+#       "html_url":"https://github.com/owner/repo/pull/12400",
+#       "merged":true,
+#       "merged_by":{"login":"tester"},
+#       "merged_at":"2025-12-21T00:00:00Z",
+#       "merge_commit_sha":"signedsha-script"
+#     },
+#     "repository":{"full_name":"owner/repo"}
+#   }'
+#   ./scripts/webhook-send.sh pull_request my-delivery-id "$payload"
+#
+#   # ファイルから送る（改行ありJSON向け）
+#   ./scripts/webhook-send.sh pull_request my-delivery-id @payload.json
+
+EVENT_NAME="${1:-}"
+DELIVERY_ID="${2:-}"
+BODY_ARG="${3:-}"
+
+if [[ -z "$EVENT_NAME" || -z "$DELIVERY_ID" || -z "$BODY_ARG" ]]; then
+  echo "Usage: $0 <event_name> <delivery_id> <json_body|@file.json>" >&2
+  exit 1
+fi
+
+: "${NGROK_BASE:?NGROK_BASE is required (e.g. https://xxxx.ngrok-free.app)}"
+: "${GITHUB_WEBHOOK_SECRET:?GITHUB_WEBHOOK_SECRET is required}"
+
+command -v openssl >/dev/null 2>&1 || { echo "openssl is required" >&2; exit 1; }
+command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
+
+URL="${NGROK_BASE%/}/api/github/webhook"
+
+# BODY を作る（@file 対応）
+if [[ "$BODY_ARG" == @* ]]; then
+  FILE_PATH="${BODY_ARG#@}"
+  if [[ ! -f "$FILE_PATH" ]]; then
+    echo "JSON file not found: $FILE_PATH" >&2
+    exit 1
+  fi
+  BODY="$(cat "$FILE_PATH")"
+else
+  BODY="$BODY_ARG"
+fi
+
+# 署名（sha256=<hex>）
+# openssl の出力は環境で微妙に違うので、末尾のHEXだけを確実に抜く
+HEX="$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$GITHUB_WEBHOOK_SECRET" | sed 's/^.* //')"
+SIG="sha256=$HEX"
+
+# リクエスト（改行・空白を含む JSON でも壊れないよう --data-binary）
+curl -sS -X POST "$URL" \
+  -H "content-type: application/json" \
+  -H "x-github-event: $EVENT_NAME" \
+  -H "x-github-delivery: $DELIVERY_ID" \
+  -H "x-hub-signature-256: $SIG" \
+  --data-binary "$BODY"
+echo

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -49,7 +49,6 @@ function parseRawPayload(rawBody: string): Prisma.InputJsonValue {
   try {
     return JSON.parse(rawBody) as Prisma.InputJsonValue
   } catch {
-    // Json カラムに string も入る（PrismaのJsonValue）
     return rawBody as unknown as Prisma.InputJsonValue
   }
 }
@@ -60,7 +59,6 @@ function isObjectPayload(rawPayload: Prisma.InputJsonValue): rawPayload is Prism
 
 /**
  * pull_request の最低限の shape チェック
- * - ここを通れば payload.action / payload.pull_request / payload.repository を安全に参照できる
  */
 function isPullRequestMergedPayload(x: Prisma.JsonObject): x is PullRequestMergedPayload {
   const o = x as Record<string, unknown>
@@ -110,7 +108,6 @@ async function findOrCreateDeliveryLog(params: {
     })
   } catch (e) {
     if (isKnownRequestError(e) && e.code === "P2002") {
-      // create レース → 取り直し
       const again = await prisma.githubWebhookDelivery.findUnique({
         where: { deliveryId },
         select: { id: true, status: true, attemptCount: true, githubEventId: true },
@@ -148,7 +145,7 @@ export async function POST(req: NextRequest) {
   const eventName = req.headers.get("x-github-event") ?? "unknown"
   const signature256 = req.headers.get("x-hub-signature-256")
 
-  // raw body
+  // raw body（署名検証のために必ず text）
   const rawBody = await req.text()
   const rawPayload = parseRawPayload(rawBody)
 
@@ -182,7 +179,6 @@ export async function POST(req: NextRequest) {
 
   // =====================================================
   // 2) 今回の試行を記録（attemptCount++, lastAttemptAt, status=RECEIVED）
-  // - processedAt は “完了時のみ” set（ここで null にしない）
   // =====================================================
   await prisma.githubWebhookDelivery.update({
     where: { deliveryId },
@@ -198,22 +194,26 @@ export async function POST(req: NextRequest) {
   })
 
   // =====================================================
-  // 2.5) 署名検証（本番のみ）
-  // - 署名NGでも delivery log を FAILED にして残す（調査性UP）
+  // 2.5) 署名検証（厳密化）
+  // - 原則: 常に検証（missing/format/mismatch も 401）
+  // - 例外: SKIP_GITHUB_SIGNATURE_VERIFY=1 のときだけスキップ
   // =====================================================
-  const isDev = process.env.NODE_ENV !== "production"
-  if (!isDev) {
-    const valid = verifyGithubSignature({ secret, payload: rawBody, signature256 })
-    if (!valid) {
+  const skipVerify = process.env.SKIP_GITHUB_SIGNATURE_VERIFY === "1"
+  if (!skipVerify) {
+    const verified = verifyGithubSignature({ secret, payload: rawBody, signature256 })
+    if (!verified.ok) {
       await prisma.githubWebhookDelivery.update({
         where: { deliveryId },
         data: {
           status: "FAILED",
           processedAt: new Date(),
-          errorMessage: "Invalid signature",
+          errorMessage: `Invalid signature: ${verified.reason}`,
         },
       })
-      return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+      return NextResponse.json(
+        { error: "Invalid signature", reason: verified.reason },
+        { status: 401 },
+      )
     }
   }
 
@@ -247,7 +247,7 @@ export async function POST(req: NextRequest) {
   }
 
   // =====================================================
-  // 3.6) JSONはobjectだが、想定shapeではない → FAILED（障害調査しやすく）
+  // 3.6) JSONはobjectだが、想定shapeではない → FAILED
   // =====================================================
   if (!isPullRequestMergedPayload(rawPayload)) {
     await prisma.githubWebhookDelivery.update({
@@ -261,7 +261,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid payload shape" }, { status: 400 })
   }
 
-  // ここで payload は型安全
   const payload = rawPayload
   const { action, pull_request, repository } = payload
 
@@ -277,14 +276,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: true, ignored: true, reason: "not merged PR" })
   }
 
-  // merge 情報
   const mergedBy = pull_request.merged_by?.login ?? null
   const mergedAt = pull_request.merged_at ? new Date(pull_request.merged_at) : null
   const mergeCommitSha = pull_request.merge_commit_sha ?? null
 
   // =====================================================
-  // 4) 本処理（GithubEvent upsert）→ 成功/失敗を delivery に反映
-  // - upsert と status 更新を transaction でまとめる（整合性UP）
+  // 4) 本処理（GithubEvent upsert）→ delivery に反映
   // =====================================================
   try {
     const result = await prisma.$transaction(async (tx) => {

--- a/src/lib/github/verifySignature.ts
+++ b/src/lib/github/verifySignature.ts
@@ -1,29 +1,50 @@
 // src/lib/github/verifySignature.ts
-import crypto from "node:crypto"
+import { createHmac, timingSafeEqual } from "node:crypto"
 
-export function verifyGithubSignature(opts: {
+export type VerifyGithubSignatureResult =
+  | { ok: true }
+  | {
+      ok: false
+      reason:
+        | "missing_header"
+        | "missing_sha256_prefix"
+        | "invalid_hex"
+        | "invalid_hex_length"
+        | "mismatch"
+    }
+
+export function verifyGithubSignature(args: {
   secret: string
   payload: string
-  signature256?: string | null
-}): boolean {
-  const { secret, payload } = opts
-  let { signature256 } = opts
+  signature256: string | null
+}): VerifyGithubSignatureResult {
+  const { secret, payload, signature256 } = args
 
-  if (!signature256) return false
+  // header 必須
+  if (!signature256) return { ok: false, reason: "missing_header" }
 
-  signature256 = signature256.trim()
-  const [algo, sigPart] = signature256.split("=")
-  const signature = sigPart?.trim()
+  const header = signature256.trim()
 
-  if (algo !== "sha256" || !signature) return false
+  // "sha256=" 必須
+  if (!header.toLowerCase().startsWith("sha256=")) {
+    return { ok: false, reason: "missing_sha256_prefix" }
+  }
 
-  const hmac = crypto.createHmac("sha256", secret)
-  const digest = hmac.update(payload, "utf8").digest("hex")
+  const hex = header.slice("sha256=".length).trim()
 
-  const sigBuf = Buffer.from(signature, "hex")
-  const digestBuf = Buffer.from(digest, "hex")
+  // 16進文字のみ
+  if (!/^[0-9a-fA-F]+$/.test(hex)) return { ok: false, reason: "invalid_hex" }
 
-  if (sigBuf.length !== digestBuf.length) return false
+  // sha256 は 32bytes = 64hex
+  if (hex.length !== 64) return { ok: false, reason: "invalid_hex_length" }
 
-  return crypto.timingSafeEqual(sigBuf, digestBuf)
+  const expectedHex = createHmac("sha256", secret).update(payload, "utf8").digest("hex")
+
+  const a = Buffer.from(expectedHex, "hex")
+  const b = Buffer.from(hex.toLowerCase(), "hex")
+
+  if (a.length !== b.length) return { ok: false, reason: "mismatch" }
+
+  const ok = timingSafeEqual(a, b)
+  return ok ? { ok: true } : { ok: false, reason: "mismatch" }
 }


### PR DESCRIPTION
## 概要

GitHub Webhook の署名検証（`X-Hub-Signature-256`）を本番同等レベルで厳密化しました。  
不正・不完全な署名を明確に検知し、Webhook Delivery として失敗理由を記録できるようにしています。

---

## 変更内容

### 1. 署名検証ロジックの厳密化
- `sha256=<hex>` 形式を必須化
- hex 文字列チェック（16進数のみ / 64文字固定）
- `timingSafeEqual` による安全な比較
- 失敗理由を明示的に返却
  - `missing_header`
  - `missing_sha256_prefix`
  - `invalid_format`
  - `invalid_hex_length`
  - `mismatch`

### 2. Webhook API の挙動変更
- **原則すべての環境で署名検証を実施**
- 検証失敗時は以下を行う
  - `GithubWebhookDelivery.status = FAILED`
  - `errorMessage` に失敗理由を記録
  - HTTP 401 を返却
- `SKIP_GITHUB_SIGNATURE_VERIFY=1` を設定した場合のみ検証をスキップ可能（開発・デバッグ用途）

### 3. 重複 deliveryId の安全な再送制御
- 同一 `deliveryId` の再送を検知
- `attemptCount` を正しく更新
- 重複時は処理せず結果を返却

### 4. ローカル検証環境の整備
- `ngrok + 署名付き curl` で本番同様の検証が可能
- 署名付き webhook 送信用スクリプトを追加
- README に検証手順を明記

---

## 追加ファイル / 主な修正

- `src/lib/github/verifySignature.ts`
- `src/app/api/github/webhook/route.ts`
- `scripts/webhook-send.sh`
- `README.md`
- `dotenv-cli` を devDependency に追加

---

## 動作確認

### 正常系
- ping イベント（署名あり） → `IGNORED`
- pull_request (merged) → `PROCESSED`
- DB に `GithubEvent` が作成される

### 異常系
- 署名なし → 401 / `missing_header`
- secret 不一致 → 401 / `mismatch`
- 形式不正 → 401 / 該当 reason
- いずれも `GithubWebhookDelivery.status = FAILED` を確認

---

## 破壊的変更について

- これまで開発環境で許容していた **署名なし webhook は拒否** されます
- 必要な場合は `SKIP_GITHUB_SIGNATURE_VERIFY=1` を設定してください

---

## 関連 Issue

- #32 GitHub Webhook の署名検証を厳密化する
