### PR TITLE
cSpell の警告を減らすため、プロジェクト辞書に単語を追加

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -9,7 +9,9 @@
     "webhook",
     "idempotency",
     "deliveryid",
-    "githubdeliveryid"
+    "githubdeliveryid",
+    "ngrok",
+    "signedsha"
   ],
   "ignorePaths": [
     "**/node_modules/**",


### PR DESCRIPTION
## 概要
cSpell の警告を減らすため、プロジェクト辞書に単語を追加しました。

## 変更内容
- cspell.json に以下の単語を追加
  - ngrok
  - signedsha

## 動作確認
- VSCode の cSpell 警告が該当箇所で出ないことを確認

## 補足
- 既存の動作ロジックには影響ありません（辞書更新のみ）