### PR TITLE
feat: PR webhookで本文/ラベル取得の下地を追加

### DIFF
--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -172,11 +172,6 @@ export async function POST(req: NextRequest) {
   const eventName = req.headers.get("x-github-event") ?? "unknown"
   const signature256 = req.headers.get("x-hub-signature-256")
 
-  // 開発用：今だけ返す（確認できたら消す）
-  if (process.env.DEBUG_WEBHOOK_HEADERS === "1") {
-    return NextResponse.json({ ok: true, debug: { eventName, deliveryId } })
-  }
-
   // raw body（署名検証のために必ず text）
   const rawBody = await req.text()
   const rawPayload = parseRawPayload(rawBody)

--- a/src/app/api/github/webhook/route.ts
+++ b/src/app/api/github/webhook/route.ts
@@ -2,11 +2,12 @@
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/server/db/client"
 import { verifyGithubSignature } from "@/lib/github/verifySignature"
+import { fetchPullRequestDetails } from "@/lib/github/fetchPullRequest"
 import { revalidatePath } from "next/cache"
 import { Prisma } from "@prisma/client"
 import type { WebhookDeliveryStatus } from "@prisma/client"
 
-type PullRequestMergedPayload = {
+type PullRequestPayload = {
   action: string
   pull_request: {
     number: number
@@ -16,6 +17,11 @@ type PullRequestMergedPayload = {
     merged_by: { login: string } | null
     merged_at: string | null
     merge_commit_sha: string | null
+
+    // PR webhook payload は PR オブジェクトを含むが、
+    // null/undefined の可能性もあるので optional で扱う
+    body?: string | null
+    user?: { login: string } | null
   }
   repository: { full_name: string }
 }
@@ -32,6 +38,7 @@ function isKnownRequestError(e: unknown): e is Prisma.PrismaClientKnownRequestEr
 }
 
 function shouldShortCircuit(status: WebhookDeliveryStatus) {
+  // 既に処理済み/無視済みなら同じ delivery を何度受けても即返す
   return status === "PROCESSED" || status === "IGNORED"
 }
 
@@ -49,6 +56,7 @@ function parseRawPayload(rawBody: string): Prisma.InputJsonValue {
   try {
     return JSON.parse(rawBody) as Prisma.InputJsonValue
   } catch {
+    // 署名検証失敗時などの調査用に raw text も残せるようにしておく
     return rawBody as unknown as Prisma.InputJsonValue
   }
 }
@@ -59,8 +67,9 @@ function isObjectPayload(rawPayload: Prisma.InputJsonValue): rawPayload is Prism
 
 /**
  * pull_request の最低限の shape チェック
+ * - merged は false のことも多いので boolean であることだけ確認
  */
-function isPullRequestMergedPayload(x: Prisma.JsonObject): x is PullRequestMergedPayload {
+function isPullRequestPayload(x: Prisma.JsonObject): x is PullRequestPayload {
   const o = x as Record<string, unknown>
   const pr = o["pull_request"] as Record<string, unknown> | undefined
   const repo = o["repository"] as Record<string, unknown> | undefined
@@ -107,6 +116,7 @@ async function findOrCreateDeliveryLog(params: {
       select: { id: true, status: true, attemptCount: true, githubEventId: true },
     })
   } catch (e) {
+    // 同時到達で create が競合した場合は取り直す
     if (isKnownRequestError(e) && e.code === "P2002") {
       const again = await prisma.githubWebhookDelivery.findUnique({
         where: { deliveryId },
@@ -118,9 +128,26 @@ async function findOrCreateDeliveryLog(params: {
   }
 }
 
+/**
+ * PRの変化タイミングで GitHub API から本文/ラベルを取り直したい action
+ */
+function shouldFetchDetails(action: string): boolean {
+  return [
+    "opened",
+    "edited",
+    "synchronize",
+    "labeled",
+    "unlabeled",
+    "ready_for_review",
+    "reopened",
+    "closed",
+  ].includes(action)
+}
+
 export async function POST(req: NextRequest) {
   const secret = process.env.GITHUB_WEBHOOK_SECRET
   const ownerUserId = process.env.OWNER_USER_ID
+  const githubToken = process.env.GITHUB_TOKEN // PR本文/ラベル補完用（無ければスキップ）
 
   if (!secret || !ownerUserId) {
     return NextResponse.json(
@@ -144,6 +171,11 @@ export async function POST(req: NextRequest) {
 
   const eventName = req.headers.get("x-github-event") ?? "unknown"
   const signature256 = req.headers.get("x-hub-signature-256")
+
+  // 開発用：今だけ返す（確認できたら消す）
+  if (process.env.DEBUG_WEBHOOK_HEADERS === "1") {
+    return NextResponse.json({ ok: true, debug: { eventName, deliveryId } })
+  }
 
   // raw body（署名検証のために必ず text）
   const rawBody = await req.text()
@@ -218,15 +250,12 @@ export async function POST(req: NextRequest) {
   }
 
   // =====================================================
-  // 3) 対象外イベント → IGNORED
+  // 3) 対象外イベント → IGNORED（push が来るのは “Send me everything” なので正常）
   // =====================================================
   if (eventName !== "pull_request") {
     await prisma.githubWebhookDelivery.update({
       where: { deliveryId },
-      data: {
-        status: "IGNORED",
-        processedAt: new Date(),
-      },
+      data: { status: "IGNORED", processedAt: new Date() },
     })
     return NextResponse.json({ ok: true, ignored: true, reason: "not pull_request" })
   }
@@ -237,26 +266,18 @@ export async function POST(req: NextRequest) {
   if (!isObjectPayload(rawPayload)) {
     await prisma.githubWebhookDelivery.update({
       where: { deliveryId },
-      data: {
-        status: "FAILED",
-        processedAt: new Date(),
-        errorMessage: "Invalid JSON",
-      },
+      data: { status: "FAILED", processedAt: new Date(), errorMessage: "Invalid JSON" },
     })
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
   }
 
   // =====================================================
-  // 3.6) JSONはobjectだが、想定shapeではない → FAILED
+  // 3.6) JSON は object だが、想定 shape ではない → FAILED
   // =====================================================
-  if (!isPullRequestMergedPayload(rawPayload)) {
+  if (!isPullRequestPayload(rawPayload)) {
     await prisma.githubWebhookDelivery.update({
       where: { deliveryId },
-      data: {
-        status: "FAILED",
-        processedAt: new Date(),
-        errorMessage: "Invalid payload shape",
-      },
+      data: { status: "FAILED", processedAt: new Date(), errorMessage: "Invalid payload shape" },
     })
     return NextResponse.json({ error: "Invalid payload shape" }, { status: 400 })
   }
@@ -264,46 +285,45 @@ export async function POST(req: NextRequest) {
   const payload = rawPayload
   const { action, pull_request, repository } = payload
 
-  // マージ以外は保存しない → IGNORED
-  if (action !== "closed" || !pull_request.merged) {
-    await prisma.githubWebhookDelivery.update({
-      where: { deliveryId },
-      data: {
-        status: "IGNORED",
-        processedAt: new Date(),
-      },
-    })
-    return NextResponse.json({ ok: true, ignored: true, reason: "not merged PR" })
-  }
+  const repoFullName = repository.full_name
+  const prNumber = pull_request.number
 
+  // merge 情報（mergeしてないPRでは null/false になってOK）
   const mergedBy = pull_request.merged_by?.login ?? null
   const mergedAt = pull_request.merged_at ? new Date(pull_request.merged_at) : null
   const mergeCommitSha = pull_request.merge_commit_sha ?? null
 
   // =====================================================
-  // 4) 本処理（GithubEvent upsert）→ delivery に反映
+  // 4) PR作成/更新のたびに GithubEvent を upsert（merge 以外でも保存）
   // =====================================================
   try {
-    const result = await prisma.$transaction(async (tx) => {
-      const saved = await tx.githubEvent.upsert({
+    const saved = await prisma.$transaction(async (tx) => {
+      const event = await tx.githubEvent.upsert({
         where: {
           userId_repoName_prNumber: {
             userId: ownerUserId,
-            repoName: repository.full_name,
-            prNumber: pull_request.number,
+            repoName: repoFullName,
+            prNumber,
           },
         },
         create: {
           githubDeliveryId: deliveryId,
           userId: ownerUserId,
-          repoName: repository.full_name,
-          prNumber: pull_request.number,
+          repoName: repoFullName,
+          prNumber,
           prTitle: pull_request.title,
           prUrl: pull_request.html_url,
           mergedBy,
           mergedAt,
           mergeCommitSha,
           rawPayload: payload as unknown as Prisma.InputJsonValue,
+
+          // 既存カラム（schemaで確認済み）
+          prAuthor: pull_request.user?.login ?? null,
+          prBody: pull_request.body ?? null,
+          prLabels: [] as unknown as Prisma.InputJsonValue,
+          prFetchedAt: null,
+          prFetchError: null,
         },
         update: {
           prTitle: pull_request.title,
@@ -312,6 +332,10 @@ export async function POST(req: NextRequest) {
           mergedAt,
           mergeCommitSha,
           rawPayload: payload as unknown as Prisma.InputJsonValue,
+
+          // webhook に body/user が含まれるケースがあるので反映（edited など）
+          prAuthor: pull_request.user?.login ?? null,
+          prBody: pull_request.body ?? null,
         },
         select: { id: true },
       })
@@ -321,27 +345,57 @@ export async function POST(req: NextRequest) {
         data: {
           status: "PROCESSED",
           processedAt: new Date(),
-          githubEventId: saved.id,
+          githubEventId: event.id,
           errorMessage: null,
         },
       })
 
-      return saved
+      return event
     })
 
+    // =====================================================
+    // 5) GitHub API で PR本文/ラベルを補完（任意）
+    // - GITHUB_TOKEN がない場合はスキップ
+    // =====================================================
+    if (githubToken && shouldFetchDetails(action)) {
+      try {
+        const details = await fetchPullRequestDetails({
+          token: githubToken,
+          repoFullName,
+          prNumber,
+        })
+
+        await prisma.githubEvent.update({
+          where: { id: saved.id },
+          data: {
+            prBody: details.body,
+            prAuthor: details.authorLogin,
+            prLabels: details.labels as unknown as Prisma.InputJsonValue,
+            prFetchedAt: new Date(),
+            prFetchError: null,
+          },
+        })
+      } catch (e) {
+        const msg = toErrorMessage(e)
+        await prisma.githubEvent.update({
+          where: { id: saved.id },
+          data: {
+            prFetchedAt: new Date(),
+            prFetchError: msg,
+          },
+        })
+      }
+    }
+
     revalidatePath("/dashboard")
-    return NextResponse.json({ ok: true, id: result.id })
+    return NextResponse.json({ ok: true, id: saved.id, action })
   } catch (err) {
     const msg = toErrorMessage(err)
     console.error("[github-webhook] failed to upsert event", err)
 
     await prisma.githubWebhookDelivery.update({
       where: { deliveryId },
-      data: {
-        status: "FAILED",
-        processedAt: new Date(),
-        errorMessage: msg,
-      },
+      data: { status: "FAILED", processedAt: new Date(), errorMessage: msg },
     })
 
     return NextResponse.json({ error: "Failed to save event" }, { status: 500 })

--- a/src/lib/github/fetchPullRequest.ts
+++ b/src/lib/github/fetchPullRequest.ts
@@ -1,0 +1,38 @@
+// src/lib/github/fetchPullRequest.ts
+type GithubPullRequestResponse = {
+  title: string
+  body: string | null
+  user: { login: string } | null
+  labels: { name: string }[]
+}
+
+export async function fetchPullRequestDetails(params: {
+  token: string
+  repoFullName: string // "owner/repo"
+  prNumber: number
+}) {
+  const { token, repoFullName, prNumber } = params
+
+  const url = `https://api.github.com/repos/${repoFullName}/pulls/${prNumber}`
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    cache: "no-store",
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "")
+    throw new Error(`GitHub API error: ${res.status} ${res.statusText} ${text}`)
+  }
+
+  const data = (await res.json()) as GithubPullRequestResponse
+
+  return {
+    body: data.body ?? null,
+    authorLogin: data.user?.login ?? null,
+    labels: data.labels?.map((l) => l.name) ?? [],
+  }
+}


### PR DESCRIPTION
## 目的
PR webhook 受信時に PR本文/ラベル等を GithubEvent に保存し、必要に応じて GitHub API で補完する下地を追加。

## 動作確認
1. Repo Settings → Webhooks で `Pull requests` イベントを有効化
2. テスト用PRを作成（PR本文を入力、ラベルを付与）
3. ローカルDBで反映確認
   ```bash
   sqlite3 dev.db "SELECT repoName, prNumber, prFetchedAt, prFetchError, LENGTH(prBody) AS prBodyLen FROM GithubEvent ORDER BY createdAt DESC LIMIT 5;"
   ```

- prBodyLen > 0 になっていること
- prFetchedAt が入っていれば GitHub API 補完が成功
---

## 2) Webhook 設定を確認（ここが最重要）
あなたのスクショでは **全部 push** になっていました。  
まず Webhook をこうしてください：

GitHub → Settings → Webhooks → 対象 webhook → Edit  
- ✅ **Pull requests** を有効化  
- （任意）Push は残してOK（route.ts では IGNORED になる設計）

保存後、`Recent Deliveries` に `pull_request` が出る状態になります。

---

## 3) “動作確認用の PR” を作る（これで pull_request が飛ぶ）
#35 のPR（実装PR）とは別に、**イベントを発生させるためのテストPR**を作るのが一番確実です。

### 3-1) テスト用ブランチ作成＆push
```bash
git checkout develop
git pull origin develop
git checkout -b test/webhook-pr-details

date > tmp_pr_webhook_test.txt
git add tmp_pr_webhook_test.txt
git commit -m "test: webhook動作確認用"
git push -u origin test/webhook-pr-details
```

### 3-2) GitHubでPR作成
- base: develop
- compare: test/webhook-pr-details
- PR本文を適当に長めに書く
- ラベルを1つ付ける（例: enhancement）

ここで pull_request opened が飛びます。

---
## 4) DBで “取れてるか” を確認（ローカル）

PR作成直後にこれを実行：
```bash
sqlite3 dev.db "SELECT repoName, prNumber, prFetchedAt, prFetchError, LENGTH(prBody) AS prBodyLen, prAuthor FROM GithubEvent ORDER BY createdAt DESC LIMIT 10;"
```
期待値：
- 新しい prNumber が増える
- prBodyLen が 0より大きい
- prFetchedAt が入っていれば GitHub API で補完成功
- prFetchError に 403/404 が入ったら、権限/リポジトリ対象の問題（切り分け可能）

ラベルも確認：
```bash
sqlite3 dev.db "SELECT prNumber, prLabels FROM GithubEvent ORDER BY createdAt DESC LIMIT 3;"

```
---
## 5) もし埋まらなかったら（即切り分け）
Webhookが pull_request として届いてるかをDBで確認：
```bash
sqlite3 dev.db "SELECT deliveryId, eventName, status, processedAt, errorMessage FROM GithubWebhookDelivery ORDER BY receivedAt DESC LIMIT 20;"
```
- eventName=pull_request が無い → Webhook設定がまだ push だけ
- pull_request はあるが prFetchedAt が空 → GitHub API補完が走ってない/失敗（prFetchErrorを見る）